### PR TITLE
Run as root in container — security tools require raw socket access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,9 @@ RUN apt-get update && apt-get install -y \
 RUN go install github.com/tomnomnom/waybackurls@latest && \
     cp /root/go/bin/waybackurls /usr/local/bin/
 
-# Create a non-root user to run the application
-RUN groupadd -r mcpuser && useradd -r -g mcpuser -m -d /home/mcpuser mcpuser
-
-# Create app directories with correct permissions
+# Create app directory
 WORKDIR /app
-COPY --chown=mcpuser:mcpuser . /app/
+COPY . /app/
 
 # Create and activate virtual environment
 RUN python3 -m venv /app/venv
@@ -63,11 +60,8 @@ RUN pip install --no-cache-dir -v \
     pytest-asyncio \
     black
 
-# Ensure appropriate output directory permissions 
-RUN touch /app/command_output.txt && chown mcpuser:mcpuser /app/command_output.txt
-
-# Switch to the non-root user
-USER mcpuser
+# Ensure appropriate output directory permissions
+RUN touch /app/command_output.txt
 
 # Expose port for SSE
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -333,13 +333,13 @@ The Docker container includes the following tools, all enabled for use through t
 | **File Analysis** | file, strings, binwalk, exiftool, xxd, hexdump |
 | **Utilities** | python3, perl, ruby, php, git, base64, jq |
 
-All commands are allowed by default inside the container. The container itself is the security boundary - it runs as a non-root user with no access to the host filesystem.
+All commands are allowed by default inside the container. The container itself is the security boundary.
 
 ## Security Considerations
 
-- **Container isolation**: The server runs inside an isolated Docker container as non-root user `mcpuser`
+- **Container isolation**: The server runs inside an isolated Docker container. Root is used inside the container because many security tools (nmap SYN scans, tcpdump, etc.) require raw socket access
 - **Input sanitization**: Shell metacharacters (`;`, `&`, `|`) are stripped from all command input
-- **No host access**: The container has no access to the host filesystem or network stack
+- **No host access**: The container has no access to the host filesystem or network stack (unless volumes are explicitly mounted)
 - **Authorization required**: Only use for legitimate security testing with proper authorization
 - **Local only**: The container should not be exposed to the internet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: Dockerfile
     image: kali-mcp-server
     container_name: kali-mcp-server
+    # Root required for raw sockets (nmap SYN scans, tcpdump, arpspoof, etc.)
     user: "0:0"
     ports:
       - "8000:8000"


### PR DESCRIPTION
Many tools (nmap SYN scans, tcpdump, arpspoof, netdiscover, etc.) need root privileges. Remove the non-root mcpuser setup from the Dockerfile and update docs to reflect that the container itself is the security boundary, not the in-container user.

